### PR TITLE
Add Sites API

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -38,6 +38,28 @@ class SiteController extends Controller
     }
 
     /**
+     * Display the specified resource.
+     *
+     * @param  \App\Site  $site
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Site $site)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Site  $site
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Site $site)
+    {
+        //
+    }
+
+    /**
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -55,5 +77,18 @@ class SiteController extends Controller
         $site->update($data);
 
         return response($site, Response::HTTP_OK);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Site  $site
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Site $site)
+    {
+        $site->delete();
+
+        return response(null, Response::HTTP_NO_CONTENT);
     }
 }

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -36,4 +36,24 @@ class SiteController extends Controller
 
         return response($site, Response::HTTP_CREATED);
     }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Site  $site
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, Site $site)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:sites,name',
+            'primary_domain' => 'url',
+            'is_enabled' => 'boolean',
+        ]);
+
+        $site->update($data);
+
+        return response($site, Response::HTTP_OK);
+    }
 }

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace Servidor\Http\Controllers;
 
-use App\Site;
+use Servidor\Site;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
@@ -40,7 +40,7 @@ class SiteController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \App\Site  $site
+     * @param  \Servidor\Site  $site
      * @return \Illuminate\Http\Response
      */
     public function show(Site $site)
@@ -51,7 +51,7 @@ class SiteController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  \App\Site  $site
+     * @param  \Servidor\Site  $site
      * @return \Illuminate\Http\Response
      */
     public function edit(Site $site)
@@ -63,7 +63,7 @@ class SiteController extends Controller
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Site  $site
+     * @param  \Servidor\Site  $site
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, Site $site)
@@ -82,7 +82,7 @@ class SiteController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\Site  $site
+     * @param  \Servidor\Site  $site
      * @return \Illuminate\Http\Response
      */
     public function destroy(Site $site)

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Site;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class SiteController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return Site::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|unique:sites,name',
+            'primary_domain' => 'url',
+            'is_enabled' => 'boolean',
+        ]);
+
+        $site = Site::create($data);
+
+        return response($site, Response::HTTP_CREATED);
+    }
+}

--- a/app/Site.php
+++ b/app/Site.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace Servidor;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/app/Site.php
+++ b/app/Site.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Site extends Model
 {
+    protected $casts = [
+        'is_enabled' => 'boolean',
+    ];
+
     protected $fillable = [
         'name',
         'primary_domain',

--- a/app/Site.php
+++ b/app/Site.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Site extends Model
+{
+    protected $fillable = [
+        'name',
+        'primary_domain',
+        'is_enabled',
+    ];
+}

--- a/database/migrations/2018_10_07_010107_create_sites_table.php
+++ b/database/migrations/2018_10_07_010107_create_sites_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSitesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sites', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->unique();
+            $table->string('primary_domain')->nullable();
+            $table->boolean('is_enabled')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sites');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,10 @@ Route::middleware('auth:api')->group(function () {
     Route::get('system-info', 'SystemInformationController');
 });
 
+Route::resource('sites', 'SiteController', [
+    'only' => ['index', 'store']
+]);
+
 Route::any('/{all?}', function () {
     abort(404);
 })->where('all', '.*');

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,7 @@ Route::middleware('auth:api')->group(function () {
 });
 
 Route::resource('sites', 'SiteController', [
-    'only' => ['index', 'store', 'update']
+    'only' => ['index', 'store', 'update', 'destroy']
 ]);
 
 Route::any('/{all?}', function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,7 @@ Route::middleware('auth:api')->group(function () {
 });
 
 Route::resource('sites', 'SiteController', [
-    'only' => ['index', 'store']
+    'only' => ['index', 'store', 'update']
 ]);
 
 Route::any('/{all?}', function () {

--- a/tests/Feature/CreateSiteTest.php
+++ b/tests/Feature/CreateSiteTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Site;
+use Tests\TestCase;
+use Illuminate\Http\Response;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CreateSiteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function testGuestCanCreateSite()
+    {
+        $response = $this->postJson('/api/sites', [
+            'name' => 'Test Site',
+            'primary_domain' => 'http://example.com',
+            'is_enabled' => true,
+        ]);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertJsonFragment([
+            'name' => 'Test Site',
+            'primary_domain' => 'http://example.com',
+            'is_enabled' => true,
+        ]);
+
+        $site = Site::first();
+        $this->assertEquals('Test Site', $site->name);
+        $this->assertEquals('http://example.com', $site->primary_domain);
+        $this->assertTrue($site->is_enabled);
+    }
+}

--- a/tests/Feature/CreateSiteTest.php
+++ b/tests/Feature/CreateSiteTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Site;
+use Servidor\Site;
 use Tests\TestCase;
 use Illuminate\Http\Response;
 use Illuminate\Foundation\Testing\WithFaker;

--- a/tests/Feature/CreateSiteTest.php
+++ b/tests/Feature/CreateSiteTest.php
@@ -37,4 +37,57 @@ class CreateSiteTest extends TestCase
         $this->assertEquals('http://example.com', $site->primary_domain);
         $this->assertTrue($site->is_enabled);
     }
+
+    public function testNameIsRequired()
+    {
+        $response = $this->postJson('/api/sites', ['name' => '']);
+
+        $this->assertValidationErrors($response, 'name');
+
+        $this->assertNull(Site::first());
+    }
+
+    public function testNameMustBeString()
+    {
+        $response = $this->postJson('/api/sites', ['name' => 42]);
+
+        $this->assertValidationErrors($response, 'name');
+
+        $this->assertNull(Site::first());
+    }
+
+    public function testNameMustBeUnique()
+    {
+        Site::create(['name' => 'Duplicate me!']);
+
+        $response = $this->postJson('/api/sites', ['name' => 'Duplicate me!']);
+
+        $this->assertValidationErrors($response, 'name');
+
+        $this->assertEquals(1, Site::count());
+    }
+
+    public function testPrimaryDomainMustBeUrl()
+    {
+        $response = $this->postJson('/api/sites', [
+            'name' => 'Good name',
+            'primary_domain' => 'not a url',
+        ]);
+
+        $this->assertValidationErrors($response, 'primary_domain');
+
+        $this->assertNull(Site::first());
+    }
+
+    public function testIsEnabledMustBeBoolean()
+    {
+        $response = $this->postJson('/api/sites', [
+            'name' => 'Good name',
+            'is_enabled' => 'true',
+        ]);
+
+        $this->assertValidationErrors($response, 'is_enabled');
+
+        $this->assertNull(Site::first());
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function assertValidationErrors($response, $keys)
+    {
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors($keys);
+    }
 }


### PR DESCRIPTION
Adds a basic Site model, migration and controller with ability to add, update and delete sites.

Implements most of #2, but for now only basic validation rules are applied.