### PR TITLE
Fixing #5, compiling with correct fonts path

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,4 +14,5 @@ const mix = require('laravel-mix');
 mix.js('resources/js/app.js', 'public/js')
    .sass('resources/sass/app.scss', 'public/css')
    .copy('node_modules/semantic-ui-css/semantic.min.css', 'public/css/')
+   .copy('node_modules/semantic-ui-css/themes/default/assets/fonts', 'public/css/themes/default/assets/fonts')
    .browserSync('localhost:8000')


### PR DESCRIPTION
Sematic-Ui seems to have some trouble with webpack compilation. See 
https://github.com/Semantic-Org/Semantic-UI/issues/3533
https://medium.com/webmonkeys/webpack-2-semantic-ui-theming-a216ddf60daf

To bypass this limitation in a conservative manner, I introduce another step during assets compilation. Hope helps. :-)