### PR TITLE
Add basic User/Group lists

### DIFF
--- a/app/Http/Controllers/System/GroupsController.php
+++ b/app/Http/Controllers/System/GroupsController.php
@@ -25,4 +25,14 @@ class GroupsController extends Controller
 
         return $groups->keyBy('id');
     }
+
+    /**
+     * Render the groups list page
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function list()
+    {
+        return view('system.groups');
+    }
 }

--- a/app/Http/Controllers/System/GroupsController.php
+++ b/app/Http/Controllers/System/GroupsController.php
@@ -27,7 +27,7 @@ class GroupsController extends Controller
     }
 
     /**
-     * Render the groups list page
+     * Render the System Groups page
      *
      * @return \Illuminate\Http\Response
      */

--- a/app/Http/Controllers/System/GroupsController.php
+++ b/app/Http/Controllers/System/GroupsController.php
@@ -23,7 +23,7 @@ class GroupsController extends Controller
             $groups->push(array_combine($keys, explode(':', $line)));
         }
 
-        return $groups->keyBy('id');
+        return $groups;
     }
 
     /**

--- a/app/Http/Controllers/System/GroupsController.php
+++ b/app/Http/Controllers/System/GroupsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\System;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class GroupsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        exec('cat /etc/group', $lines);
+
+        $groups = collect();
+
+        foreach ($lines as $line) {
+            list($name, $password, $id, $users) = explode(':', $line);
+
+            $groups->push(compact('name', 'password', 'id', 'users'));
+        }
+
+        return $groups;
+    }
+}

--- a/app/Http/Controllers/System/GroupsController.php
+++ b/app/Http/Controllers/System/GroupsController.php
@@ -16,14 +16,13 @@ class GroupsController extends Controller
     {
         exec('cat /etc/group', $lines);
 
+        $keys = ['name', 'password', 'id', 'users'];
         $groups = collect();
 
         foreach ($lines as $line) {
-            list($name, $password, $id, $users) = explode(':', $line);
-
-            $groups->push(compact('name', 'password', 'id', 'users'));
+            $groups->push(array_combine($keys, explode(':', $line)));
         }
 
-        return $groups;
+        return $groups->keyBy('id');
     }
 }

--- a/app/Http/Controllers/System/UsersController.php
+++ b/app/Http/Controllers/System/UsersController.php
@@ -23,6 +23,6 @@ class UsersController extends Controller
             $users->push(array_combine($keys, explode(':', $line)));
         }
 
-        return $users->keyBy('id');
+        return $users;
     }
 }

--- a/app/Http/Controllers/System/UsersController.php
+++ b/app/Http/Controllers/System/UsersController.php
@@ -25,4 +25,14 @@ class UsersController extends Controller
 
         return $users;
     }
+
+    /**
+     * Render the System Users page
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function list()
+    {
+        return view('system.users');
+    }
 }

--- a/app/Http/Controllers/System/UsersController.php
+++ b/app/Http/Controllers/System/UsersController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\System;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class UsersController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        exec('cat /etc/passwd', $lines);
+
+        $keys = ['username', 'password', 'id', 'group_id', 'full_name', 'home_directory', 'shell'];
+        $users = collect();
+
+        foreach ($lines as $line) {
+            $users->push(array_combine($keys, explode(':', $line)));
+        }
+
+        return $users->keyBy('id');
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,8 @@ Vue.use(SuiVue);
 Vue.component('main-menu', require('./components/MainMenu.vue'));
 Vue.component('stats-bar', require('./components/StatsBar.vue'));
 
+Vue.component('system-groups', require('./components/System/Groups.vue'));
+
 const app = new Vue({
     el: '#app'
 });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,7 @@ Vue.use(SuiVue);
 Vue.component('main-menu', require('./components/MainMenu.vue'));
 Vue.component('stats-bar', require('./components/StatsBar.vue'));
 
+Vue.component('system-menu', require('./components/System/Menu.vue'));
 Vue.component('system-groups', require('./components/System/Groups.vue'));
 
 const app = new Vue({

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -11,6 +11,7 @@ Vue.component('stats-bar', require('./components/StatsBar.vue'));
 
 Vue.component('system-menu', require('./components/System/Menu.vue'));
 Vue.component('system-groups', require('./components/System/Groups.vue'));
+Vue.component('system-users', require('./components/System/Users.vue'));
 
 const app = new Vue({
     el: '#app'

--- a/resources/js/components/MainMenu.vue
+++ b/resources/js/components/MainMenu.vue
@@ -1,7 +1,29 @@
 <template lang="html">
-    <sui-menu :widths="3">
-        <a is="sui-menu-item" href="/apps">Applications</a>
-        <a is="sui-menu-item" href="/databases">Databases</a>
-        <a is="sui-menu-item" href="/files">Filesystem</a>
+    <sui-menu :widths="menu.length">
+        <sui-menu-item link :href="item.href" v-for="(item, id) in menu" :key="id">
+            {{ item.name }}
+        </sui-menu-item>
     </sui-menu>
 </template>
+
+<script>
+export default {
+    data () {
+        return {
+            menu: [{
+                name: 'Applications',
+                href: '/apps'
+            }, {
+                name: 'Databases',
+                href: '/databases'
+            }, {
+                name: 'Files',
+                href: '/files'
+            }, {
+                name: 'System',
+                href: '/system/groups'
+            }],
+        };
+    }
+}
+</script>

--- a/resources/js/components/System/Groups.vue
+++ b/resources/js/components/System/Groups.vue
@@ -1,6 +1,10 @@
 <template>
+<div>
+    <sui-input placeholder="Search Groups..." class="huge fluid" v-model="search" />
+
     <sui-list divided relaxed>
-        <sui-list-item v-for="group in groups" :key="group.id">
+        <sui-list-item v-for="group in filteredGroups" :key="group.id"
+            v-if="group.name.includes(search)">
             <sui-list-icon name="users" size="large" vertical-align="middle"></sui-list-icon>
             <sui-list-content>
                 <a is="sui-list-header">{{ group.name }}</a>
@@ -15,6 +19,7 @@
             </sui-list-content>
         </sui-list-item>
     </sui-list>
+</div>
 </template>
 
 <script>
@@ -22,10 +27,16 @@ export default {
     data () {
         return {
             groups: [],
+            search: '',
         };
     },
     mounted () {
         this.fetchGroups();
+    },
+    computed: {
+        filteredGroups() {
+            return this.groups.filter(group => group.name.includes(this.search));
+        },
     },
     methods: {
         fetchGroups() {

--- a/resources/js/components/System/Groups.vue
+++ b/resources/js/components/System/Groups.vue
@@ -1,0 +1,30 @@
+<template>
+    <sui-list divided relaxed>
+        <sui-list-item v-for="group in groups" :key="group.id">
+            <sui-list-icon name="users" size="large" vertical-align="middle"></sui-list-icon>
+            <sui-list-content>
+                <a is="sui-list-header">{{ group.name }}</a>
+            </sui-list-content>
+        </sui-list-item>
+    </sui-list>
+</template>
+
+<script>
+export default {
+    data () {
+        return {
+            groups: [],
+        };
+    },
+    mounted () {
+        this.fetchGroups();
+    },
+    methods: {
+        fetchGroups() {
+            axios.get('/api/system/groups').then(response => {
+                this.groups = response.data;
+            });
+        },
+    },
+}
+</script>

--- a/resources/js/components/System/Groups.vue
+++ b/resources/js/components/System/Groups.vue
@@ -4,6 +4,14 @@
             <sui-list-icon name="users" size="large" vertical-align="middle"></sui-list-icon>
             <sui-list-content>
                 <a is="sui-list-header">{{ group.name }}</a>
+                <sui-list-description>
+                    <sui-list bulleted horizontal>
+                        <span v-for="(user, id) in group.users.split(',')"
+                            :key="id" is="sui-list-item">
+                            {{ user }}
+                        </span>
+                    </sui-list>
+                </sui-list-description>
             </sui-list-content>
         </sui-list-item>
     </sui-list>

--- a/resources/js/components/System/Menu.vue
+++ b/resources/js/components/System/Menu.vue
@@ -14,6 +14,9 @@ export default {
             menu: [{
                 name: 'Groups',
                 href: '/system/groups'
+            }, {
+                name: 'Users',
+                href: '/system/users'
             }],
         };
     }

--- a/resources/js/components/System/Menu.vue
+++ b/resources/js/components/System/Menu.vue
@@ -1,0 +1,21 @@
+<template>
+    <sui-menu fluid vertical tabular>
+        <a is="sui-menu-item"
+            v-for="(item, id) in menu" :key="id"
+            :content="item.name" :href="item.href">
+        </a>
+    </sui-menu>
+</template>
+
+<script>
+export default {
+    data () {
+        return {
+            menu: [{
+                name: 'Groups',
+                href: '/system/groups'
+            }],
+        };
+    }
+}
+</script>

--- a/resources/js/components/System/Users.vue
+++ b/resources/js/components/System/Users.vue
@@ -1,0 +1,41 @@
+<template>
+<div>
+    <sui-input placeholder="Search Users..." class="huge fluid" v-model="search" />
+
+    <sui-list divided relaxed>
+        <sui-list-item v-for="user in filteredUsers" :key="user.id"
+            v-if="user.username.includes(search)">
+            <sui-list-icon name="users" size="large" vertical-align="middle"></sui-list-icon>
+            <sui-list-content>
+                <a is="sui-list-header">{{ user.username }}</a>
+            </sui-list-content>
+        </sui-list-item>
+    </sui-list>
+</div>
+</template>
+
+<script>
+export default {
+    data () {
+        return {
+            users: [],
+            search: '',
+        };
+    },
+    mounted () {
+        this.fetchUsers();
+    },
+    computed: {
+        filteredUsers () {
+            return this.users.filter(user => user.username.includes(this.search));
+        },
+    },
+    methods: {
+        fetchUsers () {
+            axios.get('/api/system/users').then(response => {
+                this.users = response.data;
+            });
+        },
+    },
+}
+</script>

--- a/resources/views/layouts/system.blade.php
+++ b/resources/views/layouts/system.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section ('content')
+    <sui-grid>
+        <sui-grid-column :width="4">
+            <system-menu></system-menu>
+        </sui-grid-column>
+
+        <sui-grid-column stretched :width="12">
+            <sui-segment>
+                @yield('system-content')
+            </sui-segment>
+        </sui-grid-column>
+    </sui-grid>
+@stop

--- a/resources/views/system/groups.blade.php
+++ b/resources/views/system/groups.blade.php
@@ -1,0 +1,7 @@
+@extends ('layouts.app')
+
+@section ('content')
+    @parent
+
+    <system-groups></system-groups>
+@endsection

--- a/resources/views/system/groups.blade.php
+++ b/resources/views/system/groups.blade.php
@@ -1,7 +1,5 @@
-@extends ('layouts.app')
+@extends ('layouts.system')
 
-@section ('content')
-    @parent
-
+@section ('system-content')
     <system-groups></system-groups>
 @endsection

--- a/resources/views/system/users.blade.php
+++ b/resources/views/system/users.blade.php
@@ -1,0 +1,5 @@
+@extends ('layouts.system')
+
+@section ('system-content')
+    <system-users></system-users>
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,3 +16,9 @@ use Illuminate\Http\Request;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::name('system')->prefix('/system')->namespace('System')->group(function () {
+    Route::resource('groups', 'GroupsController', [
+        'only' => ['index'],
+    ]);
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,4 +21,8 @@ Route::name('system')->prefix('/system')->namespace('System')->group(function ()
     Route::resource('groups', 'GroupsController', [
         'only' => ['index'],
     ]);
+
+    Route::resource('users', 'UsersController', [
+        'only' => ['index'],
+    ]);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,4 +21,5 @@ Route::get('apps', function () {
 
 Route::prefix('system/')->group(function () {
     Route::get('groups', 'System\GroupsController@list');
+    Route::get('users', 'System\UsersController@list');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,3 +18,7 @@ Route::get('/', function () {
 Route::get('apps', function () {
     return view('sites');
 });
+
+Route::prefix('system/')->group(function () {
+    Route::get('groups', 'System\GroupsController@list');
+});

--- a/tests/Feature/ListSystemGroupsTest.php
+++ b/tests/Feature/ListSystemGroupsTest.php
@@ -19,4 +19,14 @@ class ListSystemGroupsTest extends TestCase
             'name' => 'root',
         ]);
     }
+
+    /** @test */
+    public function listIsAnArray()
+    {
+        $response = $this->getJson('/api/system/groups');
+
+        $responseJson = json_decode($response->getContent());
+
+        $this->assertEquals('array', gettype($responseJson));
+    }
 }

--- a/tests/Feature/ListSystemGroupsTest.php
+++ b/tests/Feature/ListSystemGroupsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Http\Response;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ListSystemGroupsTest extends TestCase
+{
+    /** @test */
+    public function canViewGroupsList()
+    {
+        $response = $this->getJson('/api/system/groups');
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'name' => 'root',
+        ]);
+    }
+}

--- a/tests/Feature/ListSystemUsersTest.php
+++ b/tests/Feature/ListSystemUsersTest.php
@@ -30,4 +30,16 @@ class ListSystemUsersTest extends TestCase
             'username' => 'root'
         ]);
     }
+
+    /**
+     * @test
+     */
+    public function listIsAnArray()
+    {
+        $response = $this->getJson('/api/system/users');
+
+        $responseJson = json_decode($response->getContent());
+
+        $this->assertEquals('array', gettype($responseJson));
+    }
 }

--- a/tests/Feature/ListSystemUsersTest.php
+++ b/tests/Feature/ListSystemUsersTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Http\Response;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ListSystemUsersTest extends TestCase
+{
+    /** @test */
+    public function listIncludesSystemUsers()
+    {
+        $response = $this->getJson('/api/system/users');
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'username' => 'nobody',
+        ]);
+    }
+
+    /** @test */
+    public function listIncludesNormalUsers()
+    {
+        $response = $this->getJson('/api/system/users');
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'username' => 'root'
+        ]);
+    }
+}


### PR DESCRIPTION
Adds `GET` API endpoints for system users and groups (#19), with corresponding frontend list views.

Lists can be filtered, but there's no edit functionality yet.