### PR TITLE
Maintain Nginx configs when changing Sites

### DIFF
--- a/app/Events/SiteUpdated.php
+++ b/app/Events/SiteUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Servidor\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Servidor\Site;
+
+class SiteUpdated
+{
+    use SerializesModels;
+
+    /**
+     * @var Site
+     */
+    public $site;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Site $site)
+    {
+        $this->site = $site;
+    }
+}

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Servidor\Listeners;
+
+use Servidor\Events\SiteUpdated;
+
+class WriteSiteConfig
+{
+    /**
+     * Handle the event.
+     *
+     * @param SiteUpdated $event
+     */
+    public function handle(SiteUpdated $event)
+    {
+        $site = $event->site;
+
+        if ($site->document_root && !is_dir($site->document_root)) {
+            mkdir($site->document_root, 755);
+        }
+    }
+}

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -34,6 +34,10 @@ class WriteSiteConfig
      */
     public function handle(SiteUpdated $event)
     {
+        if (!is_dir('/etc/nginx/sites-available')) {
+            return;
+        }
+
         $site = $this->site = $event->site;
         $filename = $this->filename = $site->primary_domain.'.conf';
         $this->config_path = '/etc/nginx/sites-available/'.$filename;
@@ -56,11 +60,6 @@ class WriteSiteConfig
             : view('sites.server-templates.'.$this->site->type);
 
         Storage::put('vhosts/'.$this->filename, $view->with('site', $this->site));
-
-        // This is purely to keep Travis happy. Ideally we should probably
-        // do something if nginx isn't installed because now I'm fixing
-        // this error it'll no doubt fail on restarting the service.
-        exec('sudo mkdir -p /etc/nginx/sites-{available,enabled}');
 
         $file = Storage::disk('local')->path('vhosts/'.$this->filename);
         exec('sudo cp "'.$file.'" "'.$this->config_path.'"');

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -57,6 +57,11 @@ class WriteSiteConfig
 
         Storage::put('vhosts/'.$this->filename, $view->with('site', $this->site));
 
+        // This is purely to keep Travis happy. Ideally we should probably
+        // do something if nginx isn't installed because now I'm fixing
+        // this error it'll no doubt fail on restarting the service.
+        exec('sudo mkdir -p /etc/nginx/sites-{available,enabled}');
+
         $file = Storage::disk('local')->path('vhosts/'.$this->filename);
         exec('sudo cp "'.$file.'" "'.$this->config_path.'"');
     }

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -2,6 +2,7 @@
 
 namespace Servidor\Listeners;
 
+use Illuminate\Support\Facades\Storage;
 use Servidor\Events\SiteUpdated;
 
 class WriteSiteConfig
@@ -18,5 +19,14 @@ class WriteSiteConfig
         if ($site->document_root && !is_dir($site->document_root)) {
             mkdir($site->document_root, 755);
         }
+
+        $filename = $site->primary_domain.'.conf';
+        $filepath = 'vhosts/'.$filename;
+        $fullpath = Storage::disk('local')->path($filepath);
+
+        $template = 'laravel' == $site->type ? 'php' : $site->type;
+
+        Storage::put($filepath, view('sites.server-templates.'.$template, ['site' => $site]));
+        exec('sudo cp "'.$fullpath.'" "/etc/nginx/sites-available/'.$filename.'"');
     }
 }

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -23,10 +23,18 @@ class WriteSiteConfig
         $filename = $site->primary_domain.'.conf';
         $filepath = 'vhosts/'.$filename;
         $fullpath = Storage::disk('local')->path($filepath);
+        $confpath = '/etc/nginx/sites-available/'.$filename;
+        $livepath = '/etc/nginx/sites-enabled/'.$filename;
 
         $template = 'laravel' == $site->type ? 'php' : $site->type;
 
         Storage::put($filepath, view('sites.server-templates.'.$template, ['site' => $site]));
-        exec('sudo cp "'.$fullpath.'" "/etc/nginx/sites-available/'.$filename.'"');
+        exec('sudo cp "'.$fullpath.'" "'.$confpath.'"');
+
+        if ($site->is_enabled && !is_link($livepath)) {
+            exec('sudo ln -s "'.$confpath.'" "'.$livepath.'"');
+        }
+
+        exec('sudo systemctl reload-or-restart nginx.service');
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -18,6 +18,9 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        'Servidor\Events\SiteUpdated' => [
+            'Servidor\Listeners\WriteSiteConfig',
+        ],
     ];
 
     /**

--- a/app/Site.php
+++ b/app/Site.php
@@ -3,11 +3,16 @@
 namespace Servidor;
 
 use Illuminate\Database\Eloquent\Model;
+use Servidor\Events\SiteUpdated;
 
 class Site extends Model
 {
     protected $casts = [
         'is_enabled' => 'boolean',
+    ];
+
+    protected $dispatchesEvents = [
+        'updated' => SiteUpdated::class,
     ];
 
     protected $fillable = [

--- a/resources/views/sites/server-templates/basic.blade.php
+++ b/resources/views/sites/server-templates/basic.blade.php
@@ -1,0 +1,10 @@
+server {
+    server_name {{ $site->primary_domain }};
+
+    root {{ $site->document_root }};
+    index index.html index.htm;
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/resources/views/sites/server-templates/php.blade.php
+++ b/resources/views/sites/server-templates/php.blade.php
@@ -1,0 +1,24 @@
+server {
+    server_name {{ $site->primary_domain }};
+
+    root {{ $site->document_root }};
+    index index.php index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.php?query_string;
+
+        location ~ \.php$ {
+            try_files $uri =404;
+
+            fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+            include fastcgi_params;
+        }
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/resources/views/sites/server-templates/redirect.blade.php
+++ b/resources/views/sites/server-templates/redirect.blade.php
@@ -1,0 +1,5 @@
+server {
+    server_name {{ $site->primary_domain }};
+
+    return {{ $site->redirect_type }} {{ $site->redirect_to }};
+}

--- a/tests/Feature/SitesApiTest.php
+++ b/tests/Feature/SitesApiTest.php
@@ -131,6 +131,7 @@ class SitesApiTest extends TestCase
             'type' => 'basic',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'document_root' => '/var/www/blog',
+            'primary_domain' => 'test.com',
         ]);
 
         $updated = Site::find($site->id);

--- a/tests/Feature/SitesApiTest.php
+++ b/tests/Feature/SitesApiTest.php
@@ -129,7 +129,7 @@ class SitesApiTest extends TestCase
         $response = $this->authed()->putJson('/api/sites/'.$site->id, [
             'name' => 'My Updated Blog',
             'type' => 'basic',
-            'source_repo' => 'https://github.com/user/blog.git',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'document_root' => '/var/www/blog',
         ]);
 
@@ -138,7 +138,7 @@ class SitesApiTest extends TestCase
         $response->assertOk();
         $this->assertEquals('My Updated Blog', $updated->name);
         $this->assertEquals('basic', $updated->type);
-        $this->assertEquals('https://github.com/user/blog.git', $updated->source_repo);
+        $this->assertEquals('https://github.com/dshoreman/servidor-test-site.git', $updated->source_repo);
         $this->assertEquals('/var/www/blog', $updated->document_root);
     }
 

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -56,6 +56,8 @@ configure_app() {
 
     cd /var/servidor && echo "Configuring application..."
 
+    chown www-data:www-data /var/www
+
     echo "CREATE USER 'servidor'@'localhost' IDENTIFIED BY 'vagrant'" | mysql && \
         echo "GRANT ALL PRIVILEGES ON *.* TO 'servidor'@'localhost'" | mysql && \
         echo "FLUSH PRIVILEGES; CREATE DATABASE servidor" | mysql && \


### PR DESCRIPTION
When updating a Site/Application, this PR adds a selection of Blade templates with dummy Nginx configs. These are used to create the site's Nginx server config in `/etc/nginx/sites-available`. It will also clone the source repo into the document root, although there's no way of setting the branch currently.

Closes #58
Closes #62