### PR TITLE
Add switch to change Sites' is_enabled flag

### DIFF
--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -1,13 +1,17 @@
 <template>
     <sui-container>
-        <h2 is="sui-header">
-            Editing {{ site.name }}
-            <sui-header-subheader>
-                {{ site.primary_domain }}
-            </sui-header-subheader>
-        </h2>
-
         <sui-form @submit.prevent="updateSite(tmpSite.id)" :error="error != ''">
+            <sui-form-field class="enable-switch">
+                <sui-checkbox toggle v-model="tmpSite.is_enabled"/>
+            </sui-form-field>
+
+            <h2 is="sui-header">
+                Editing {{ site.name }}
+                <sui-header-subheader>
+                    {{ site.primary_domain }}
+                </sui-header-subheader>
+            </h2>
+
             <sui-message error :header="errorHeader">
                 <p>{{ error }}</p>
             </sui-message>
@@ -97,6 +101,13 @@
         </sui-form>
     </sui-container>
 </template>
+
+<style scoped>
+.ui.form .field.enable-switch {
+    float: right;
+    margin-top: 5px;
+}
+</style>
 
 <script>
 import { mapState } from 'vuex';


### PR DESCRIPTION
Moves the form tag to be above the header so that we can jam the
is_enabled toggle switch (technically a checkbox hence needing it in the
form) between it and the header. That way we can float it to the right
and it's kept out the way of the rest of the stuff.

Fixes #85.