### PR TITLE
Add source branch field to Sites

### DIFF
--- a/app/Http/Requests/UpdateSite.php
+++ b/app/Http/Requests/UpdateSite.php
@@ -34,6 +34,7 @@ class UpdateSite extends FormRequest
             'primary_domain' => [new Domain],
             'type' => 'required|in:basic,php,laravel,redirect',
             'source_repo' => 'required_unless:type,redirect|nullable|url',
+            'source_branch' => 'nullable|string',
             'document_root' => 'required_unless:type,redirect|nullable|string',
             'redirect_type' => 'required_if:type,redirect|nullable|integer',
             'redirect_to' => 'required_if:type,redirect|nullable|string',

--- a/app/Http/Requests/UpdateSite.php
+++ b/app/Http/Requests/UpdateSite.php
@@ -56,22 +56,14 @@ class UpdateSite extends FormRequest
                 return;
             }
 
-            exec(sprintf("git ls-remote --exit-code '%s' 'refs/heads/*'", $data['source_repo']), $branches, $status);
+            exec('git ls-remote --heads --exit-code "'.$data['source_repo'].'" "'.$data['source_branch'].'"', $o, $status);
 
             if (128 === $status) {
                 $validator->errors()->add('source_repo', "This repo couldn't be found. Does it require auth?");
             } elseif (2 === $status) {
-                $validator->errors()->add('source_repo', 'This repo does not have any branches.');
+                $validator->errors()->add('source_branch', "This branch doesn't exist.");
             } elseif (0 !== $status) {
                 $validator->errors()->add('source_repo', 'Branch listing failed. Is this repo valid?');
-            } else {
-                $branches = array_map(function ($value) {
-                    return mb_substr($value, 11 + mb_strpos($value, 'refs/heads/'));
-                }, $branches);
-
-                if (!in_array($data['source_branch'], $branches)) {
-                    $validator->errors()->add('source_branch', 'Branch does not exist.');
-                }
             }
         });
     }

--- a/app/Http/Requests/UpdateSite.php
+++ b/app/Http/Requests/UpdateSite.php
@@ -52,7 +52,7 @@ class UpdateSite extends FormRequest
         $validator->after(function ($validator) {
             $data = $validator->getData();
 
-            if ('' == $data['source_branch'] || '' == $data['source_repo']) {
+            if (!isset($data['source_branch'], $data['source_repo'])) {
                 return;
             }
 

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -68,13 +68,14 @@ class WriteSiteConfig
     private function pullSite()
     {
         $root = $this->site->document_root;
+        $branch = $this->site->source_branch;
 
         if (!$this->site->type || 'redirect' == $this->site->type || !$root) {
             return;
         }
 
         if (is_dir($root.'/.git')) {
-            exec('cd "'.$root.'" && git pull');
+            exec('cd "'.$root.'"'.($branch ? ' && git checkout "'.$branch.'"' : '').' && git pull');
 
             return;
         }
@@ -83,7 +84,8 @@ class WriteSiteConfig
             mkdir(dirname($root), 755);
         }
 
-        exec('git clone "'.$this->site->source_repo.'" "'.$root.'"');
+        $cloneCmd = $branch ? 'git clone --branch "'.$branch.'"' : 'git clone';
+        exec($cloneCmd.' "'.$this->site->source_repo.'" "'.$root.'"');
     }
 
     private function createSymlink()

--- a/app/Site.php
+++ b/app/Site.php
@@ -20,6 +20,7 @@ class Site extends Model
         'primary_domain',
         'type',
         'source_repo',
+        'source_branch',
         'document_root',
         'redirect_type',
         'redirect_to',

--- a/database/migrations/2019_07_31_220427_add_source_repo_to_sites_table.php
+++ b/database/migrations/2019_07_31_220427_add_source_repo_to_sites_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSourceRepoToSitesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->string('source_branch')->nullable()->after('source_repo');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->dropColumn('source_branch');
+        });
+    }
+}

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -73,14 +73,23 @@
                 </sui-form-field>
             </sui-form-fields>
 
-            <sui-form-field v-if="tmpSite.type && tmpSite.type != 'redirect'"
-                :error="'source_repo' in errors">
-                <label>Clone URL</label>
-                <sui-input v-model="tmpSite.source_repo" />
-                <sui-label basic color="red" pointing v-if="'source_repo' in errors">
-                    {{ errors.source_repo[0] }}
-                </sui-label>
-            </sui-form-field>
+            <sui-form-fields v-if="tmpSite.type && tmpSite.type != 'redirect'">
+                <sui-form-field :width="12" :error="'source_repo' in errors">
+                    <label>Clone URL</label>
+                    <sui-input v-model="tmpSite.source_repo" />
+                    <sui-label basic color="red" pointing v-if="'source_repo' in errors">
+                        {{ errors.source_repo[0] }}
+                    </sui-label>
+                </sui-form-field>
+                <sui-form-field :width="4" :error="'source_branch' in errors">
+                    <label>Branch</label>
+                    <sui-input v-model="tmpSite.source_branch" />
+                    <sui-label basic color="red" pointing v-if="'source_branch' in errors">
+                        {{ errors.source_branch[0] }}
+                    </sui-label>
+                </sui-form-field>
+            </sui-form-fields>
+
             <sui-form-field v-if="['basic', 'php', 'laravel'].includes(tmpSite.type)"
                 :error="'document_root' in errors">
                 <label>Document Root</label>


### PR DESCRIPTION
Splits the Clone URL field of the Site Editor into two columns so we can
add a new branch input next to it. Setting it doesn't do anything yet,
but this gets the groundwork laid (migration, validation etc) ready.

Closes #88.