### PR TITLE
Support filtering results from the Create Site box

### DIFF
--- a/resources/js/pages/Sites.vue
+++ b/resources/js/pages/Sites.vue
@@ -3,7 +3,7 @@
         <sui-grid-row>
             <sui-grid-column>
                 <sui-input placeholder="Type a name for your Application..."
-                        icon="plus" class="fluid massive"
+                        :icon="filterIcon" class="fluid massive"
                         v-model="site.name" @input="filterSites" @keyup.enter="createOrEdit"></sui-input>
             </sui-grid-column>
         </sui-grid-row>
@@ -27,6 +27,19 @@ export default {
             'sites',
             'filteredSites',
         ]),
+        filterIcon: function () {
+            const match = this.site.name.toLowerCase();
+
+            if (match == '') {
+                return 'search';
+            }
+
+            if ('object' == typeof(this.filteredSites.find(s => s.name.toLowerCase() == match))) {
+                return 'cogs';
+            }
+
+            return 'plus';
+        },
     },
     methods: {
         ...mapMutations({
@@ -39,9 +52,7 @@ export default {
                 return;
             }
 
-            let result = this.filteredSites.find(function (s) {
-                return s.name.toLowerCase() == match;
-            });
+            let result = this.filteredSites.find(s => s.name.toLowerCase() == match);
 
             if (typeof(result) === 'object') {
                 return this.$router.push({ name: 'apps.edit', params: { id: result.id }});

--- a/resources/js/pages/Sites.vue
+++ b/resources/js/pages/Sites.vue
@@ -4,7 +4,7 @@
             <sui-grid-column>
                 <sui-input placeholder="Type a name for your Application..."
                         icon="plus" class="fluid massive"
-                        v-model="site.name" @input="filterSites" @keyup.enter="create"></sui-input>
+                        v-model="site.name" @input="filterSites" @keyup.enter="createOrEdit"></sui-input>
             </sui-grid-column>
         </sui-grid-row>
         <router-view :sites="filteredSites"></router-view>
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
+import { mapState, mapGetters, mapMutations } from 'vuex';
 import store from '../store';
 
 export default {
@@ -29,12 +29,26 @@ export default {
         ]),
     },
     methods: {
-        ...mapActions({
-            create: 'createSite',
-        }),
         ...mapMutations({
             filterSites: 'setFilter',
         }),
+        createOrEdit: function () {
+            const match = this.site.name.toLowerCase();
+
+            if (match == '') {
+                return;
+            }
+
+            let result = this.filteredSites.find(function (s) {
+                return s.name.toLowerCase() == match;
+            });
+
+            if (typeof(result) === 'object') {
+                return this.$router.push({ name: 'apps.edit', params: { id: result.id }});
+            }
+
+            this.store.dispatch('create');
+        },
     }
 }
 </script>

--- a/resources/js/pages/Sites.vue
+++ b/resources/js/pages/Sites.vue
@@ -4,10 +4,10 @@
             <sui-grid-column>
                 <sui-input placeholder="Type a name for your Application..."
                         icon="plus" class="fluid massive"
-                        v-model="site.name" @keyup.enter="create"></sui-input>
+                        v-model="site.name" @input="filterSites" @keyup.enter="create"></sui-input>
             </sui-grid-column>
         </sui-grid-row>
-        <router-view :sites="sites"></router-view>
+        <router-view :sites="filteredSites"></router-view>
     </sui-container>
 </template>
 
@@ -25,11 +25,15 @@ export default {
         }),
         ...mapGetters([
             'sites',
+            'filteredSites',
         ]),
     },
     methods: {
         ...mapActions({
             create: 'createSite',
+        }),
+        ...mapMutations({
+            filterSites: 'setFilter',
         }),
     }
 }

--- a/resources/js/pages/Sites.vue
+++ b/resources/js/pages/Sites.vue
@@ -58,7 +58,7 @@ export default {
                 return this.$router.push({ name: 'apps.edit', params: { id: result.id }});
             }
 
-            this.store.dispatch('create');
+            this.$store.dispatch('createSite');
         },
     }
 }

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -1,5 +1,7 @@
 export default {
     state: {
+        current: {},
+        currentFilter: '',
         error: '',
         errors: [],
         error_title: '',
@@ -7,7 +9,6 @@ export default {
         site: {
             name: '',
         },
-        current: {},
     },
     mutations: {
         setErrors: (state, {message, errors, action = 'save'}) => {
@@ -17,6 +18,9 @@ export default {
             if (errors) {
                 state.errors = errors;
             }
+        },
+        setFilter: (state, value) => {
+            state.currentFilter = value;
         },
         setSites: (state, sites) => {
             state.sites = sites;
@@ -101,6 +105,11 @@ export default {
         },
     },
     getters: {
+        filteredSites: state => {
+            return state.sites.filter(site => {
+                return site.name.toLowerCase().includes(state.currentFilter.toLowerCase());
+            });
+        },
         sites: state => {
             return state.sites;
         },


### PR DESCRIPTION
This PR brings functionality from the System Users/Groups filter inputs with a few added extras that let you not only filter the list of Sites, but also open an existing one when you type in its name and hit enter.

Closes #61.