### PR TITLE
Add browse button to items in Sites list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* Buttons to navigate between Sites and their files
 
 
 ## [0.3.0] - 2019-08-13

--- a/resources/js/components/Sites/SiteItem.vue
+++ b/resources/js/components/Sites/SiteItem.vue
@@ -9,6 +9,10 @@
             <router-link :to="{ name: 'apps.edit', params: { id: site.id } }">
                 <sui-icon name="cogs"></sui-icon> Manage Site
             </router-link>
+            <router-link :to="{ name: 'files', params: { path: site.document_root } }"
+                slot="right" v-if="site.document_root != null">
+                <sui-icon name="open folder" /> Browse Files
+            </router-link>
         </sui-card-content>
     </sui-card>
 </template>

--- a/resources/js/components/Sites/SiteItem.vue
+++ b/resources/js/components/Sites/SiteItem.vue
@@ -4,10 +4,12 @@
             <sui-card-header>{{ site.name }}</sui-card-header>
             <sui-card-meta>{{ site.primary_domain }}</sui-card-meta>
         </sui-card-content>
-        <router-link is="sui-button" attached="bottom"
-            :to="{ name: 'apps.edit', params: { id: site.id } }">
-            <sui-icon name="cogs"></sui-icon> Manage Site
-        </router-link>
+
+        <sui-card-content extra>
+            <router-link :to="{ name: 'apps.edit', params: { id: site.id } }">
+                <sui-icon name="cogs"></sui-icon> Manage Site
+            </router-link>
+        </sui-card-content>
     </sui-card>
 </template>
 

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -1,6 +1,9 @@
 <template>
     <sui-container id="file-browser">
         <h2>
+            <router-link :to="{ name: 'apps.edit', params: { id: site.id }}"
+                is="sui-button" color="teal" icon="globe" floated="right"
+                id="back2site" :content="'Edit ' + site.name" v-if="site" />
             <sui-button id="levelup" size="mini" icon="level up" @click="upOneLevel"/>
             {{ currentPath }}
         </h2>
@@ -15,6 +18,7 @@ import FileList from '../../components/Files/Browser/FileList';
 
 export default {
     mounted () {
+        this.$store.dispatch('loadSites');
         this.$store.dispatch('loadFiles', { path: this.path });
     },
     props: [
@@ -26,8 +30,12 @@ export default {
     computed: {
         ...mapGetters([
             'currentPath',
+            'getSiteByDocroot',
             'files',
         ]),
+        site: function() {
+            return this.getSiteByDocroot(this.currentPath);
+        },
     },
     methods: {
         setPath: function (file) {

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -110,6 +110,9 @@ export default {
                 return site.name.toLowerCase().includes(state.currentFilter.toLowerCase());
             });
         },
+        getSiteByDocroot: (state) => (path) => {
+            return state.sites.find(s => s.document_root == path);
+        },
         sites: state => {
             return state.sites;
         },

--- a/resources/sass/_file-manager.scss
+++ b/resources/sass/_file-manager.scss
@@ -1,4 +1,5 @@
 #file-browser, #file-editor {
+    a#back2site,
     button#levelup {
         vertical-align: top;
     }


### PR DESCRIPTION
Replaces the not-so-pretty attached Manage Site button with normal links within an "extra card content" container.

This gives a much cleaner appearance and makes room for a new Browse Files button, which appears for sites with a document root and takes you to that place in the File Manager.

Also adds a corresponding button in the File Browser when the given path matches the document root of any sites to go directly to its editor page.

Closes #107.