### PR TITLE
Fix tests in clean Vagrant environment

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -61,8 +61,8 @@ configure_app() {
     chown www-data:www-data /var/www
 
     echo "CREATE USER 'servidor'@'localhost' IDENTIFIED BY 'vagrant'" | mysql && \
-        echo "GRANT ALL PRIVILEGES ON *.* TO 'servidor'@'localhost'" | mysql && \
-        echo "FLUSH PRIVILEGES; CREATE DATABASE servidor" | mysql && \
+        echo "GRANT ALL PRIVILEGES ON *.* TO 'servidor'@'localhost'; FLUSH PRIVILEGES;" | mysql && \
+        echo "CREATE DATABASE servidor; CREATE DATABASE servidor_testing;" | mysql && \
         echo "Database and user 'servidor' created."
 
     # Make sure both user and group are www-data for our tests

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -30,6 +30,9 @@ configure_nginx() {
     cp -v /var/servidor/vagrant/nginx/index.default.html /var/www/html/index.html
     rm -v /var/www/html/index.nginx-debian.html
 
+    # NOTE: This should be much more restrictive in a live environment!
+    echo "www-data ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/www-data
+
     start_service php7.3-fpm
     start_service nginx
 }


### PR DESCRIPTION
Since upgrading the Vagrant box to the latest version of Ubuntu Bionic (18.04? Who knows), tests have been broken.

This is partly because the bootstrap script isn't creating the database, but it's also failing on anything with sudo since we're not automatically adding the sudoers entries.

This PR fixes all of the above.