### PR TITLE
Handle errors when opening files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ install:
 
 before_script:
   - sudo chown -R www-data:www-data "$TRAVIS_BUILD_DIR/resources/test-skel"
+  - sudo chown -R root:root "$TRAVIS_BUILD_DIR/resources/test-skel/protected"
+  - sudo chmod 600 "$TRAVIS_BUILD_DIR/resources/test-skel/protected/forbidden"
   - mysql -e 'CREATE DATABASE servidor_test;'
   - cp .env.travis .env
   - php artisan key:generate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Icons in the File Manager are now coloured based on type (file or folder)
+* Error handling when opening files in File Manager is greatly improved
 
 
 ## [0.3.0] - 2019-08-13

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,10 @@ Vagrant.configure("2") do |config|
     create: true, owner: "www-data", group: "www-data",
     mount_options: ["dmode=775,fmode=664"]
 
+  config.vm.synced_folder "./resources/test-skel/protected", "/var/servidor/resources/test-skel/protected",
+    create: false, owner: "vagrant", group: "vagrant",
+    mount_options: ["dmode=775,fmode=600"]
+
   config.vm.provider "virtualbox" do |vb|
     vb.name = "servidor-dev"
     vb.linked_clone = true

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -38,6 +38,10 @@ class FileManager
 
     public function open($file): array
     {
+        if (!file_exists($file)) {
+            return ['error' => ['code' => 404, 'msg' => 'File not found']];
+        }
+
         return $this->fileToArray($file, true);
     }
 

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -2,6 +2,7 @@
 
 namespace Servidor\FileManager;
 
+use Illuminate\Http\Response;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -61,7 +62,17 @@ class FileManager
         ];
 
         if ($includeContents) {
-            $data['contents'] = $file->getContents();
+            try {
+                $data['contents'] = $file->getContents();
+            } catch (\RuntimeException $e) {
+                $msg = $e->getMessage();
+                $data['contents'] = '';
+
+                $data['error'] = str_contains($msg, 'Permission denied') ? [
+                    'code' => Response::HTTP_FORBIDDEN,
+                    'msg' => 'Permission denied',
+                ] : ['code' => 418, 'msg' => $msg];
+            }
         }
 
         return $data;

--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -27,11 +27,17 @@ class FileController extends Controller
     public function index(Request $request)
     {
         if ($filepath = $request->get('file')) {
-            return $this->fm->open($filepath);
+            $file = $this->fm->open($filepath);
+
+            if (array_key_exists('error', $file)) {
+                return response($file, $file['error']['code']);
+            }
+
+            return response()->json($file);
         }
 
         $path = $request->get('path');
 
-        return $this->fm->list($path);
+        return response()->json($this->fm->list($path));
     }
 }

--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -3,6 +3,7 @@
 namespace Servidor\Http\Controllers;
 
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Servidor\FileManager\FileManager;
 
 class FileController extends Controller
@@ -33,7 +34,11 @@ class FileController extends Controller
                 return response($file, $file['error']['code']);
             }
 
-            return response()->json($file);
+            try {
+                return response()->json($file);
+            } catch (InvalidArgumentException $e) {
+                return ['error' => ['code' => 422, 'msg' => 'Failed loading file']];
+            }
         }
 
         $path = $request->get('path');

--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -37,7 +37,13 @@ class FileController extends Controller
             try {
                 return response()->json($file);
             } catch (InvalidArgumentException $e) {
-                return ['error' => ['code' => 422, 'msg' => 'Failed loading file']];
+                $file['contents'] = '';
+                $file['error'] = [
+                    'code' => 422,
+                    'msg' => 'Failed loading file',
+                ];
+
+                return response()->json($file);
             }
         }
 

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -11,6 +11,7 @@
         <sui-segment class="placeholder" v-else>
             <sui-header icon>
                 <sui-icon v-if="file.error.code == 403" name="ban" color="red" />
+                <sui-icon v-else-if="file.error.code == 404" name="search" color="teal" />
                 <sui-icon v-else name="bug" color="orange" />
                 {{ file.error.msg }}
             </sui-header>

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -6,7 +6,16 @@
             {{ filePath }}
         </h2>
 
-        <pre>{{ file.contents }}</pre>
+        <pre v-if="file.error == undefined">{{ file.contents }}</pre>
+
+        <sui-segment class="placeholder" v-else>
+            <sui-header icon>
+                <sui-icon v-if="file.error.code == 403" name="ban" color="red" />
+                <sui-icon v-else name="bug" color="orange" />
+                {{ file.error.msg }}
+            </sui-header>
+        </sui-segment>
+
     </sui-container>
 </template>
 

--- a/resources/js/store/modules/FileManager.js
+++ b/resources/js/store/modules/FileManager.js
@@ -35,7 +35,16 @@ export default {
                     commit('setFile', response.data);
                     resolve(response);
                 }).catch(error => {
-                    commit('setFile', { contents: error.response.data.message })
+                    let data = error.response.data;
+
+                    if (!data.error || !data.error.code) {
+                        data = { error: {
+                            code: error.response.status,
+                            msg: data.message
+                        }};
+                    }
+
+                    commit('setFile', data);
                     reject(error);
                 })
             );

--- a/resources/test-skel/protected/forbidden
+++ b/resources/test-skel/protected/forbidden
@@ -1,0 +1,1 @@
+Can't touch this.

--- a/tests/Unit/FileManager/FileManagerTest.php
+++ b/tests/Unit/FileManager/FileManagerTest.php
@@ -100,6 +100,21 @@ class FileManagerTest extends TestCase
     }
 
     /** @test */
+    public function show_catches_runtime_exceptions()
+    {
+        $file = $this->manager->open($this->dummy('protected/forbidden'));
+
+        $this->assertIsArray($file);
+        $this->assertEmpty($file['contents']);
+        $this->assertArrayHasKey('error', $file);
+        $this->assertIsArray($file['error']);
+        $this->assertSame([
+            'code' => 403,
+            'msg' => 'Permission denied',
+        ], $file['error']);
+    }
+
+    /** @test */
     public function show_includes_details_about_the_file()
     {
         $file = $this->manager->open($this->dummy('mixed/hello.md'));

--- a/tests/Unit/FileManager/FileManagerTest.php
+++ b/tests/Unit/FileManager/FileManagerTest.php
@@ -87,7 +87,7 @@ class FileManagerTest extends TestCase
     }
 
     /** @test */
-    public function show_returns_contents_of_given_file()
+    public function open_returns_contents_of_given_file()
     {
         $file = $this->manager->open($this->dummy('mixed/hello.md'));
 
@@ -100,7 +100,7 @@ class FileManagerTest extends TestCase
     }
 
     /** @test */
-    public function show_catches_runtime_exceptions()
+    public function open_catches_permission_denied_errors()
     {
         $file = $this->manager->open($this->dummy('protected/forbidden'));
 
@@ -115,7 +115,21 @@ class FileManagerTest extends TestCase
     }
 
     /** @test */
-    public function show_includes_details_about_the_file()
+    public function open_catches_stat_failed_error_when_file_does_not_exist()
+    {
+        $file = $this->manager->open($this->dummy('invalid/file'));
+
+        $this->assertIsArray($file);
+        $this->assertArrayHasKey('error', $file);
+        $this->assertIsArray($file['error']);
+        $this->assertSame([
+            'code' => 404,
+            'msg' => 'File not found',
+        ], $file['error']);
+    }
+
+    /** @test */
+    public function open_includes_details_about_the_file()
     {
         $file = $this->manager->open($this->dummy('mixed/hello.md'));
         unset($file['contents']);
@@ -133,7 +147,7 @@ class FileManagerTest extends TestCase
     }
 
     /** @test */
-    public function show_follows_symlinks()
+    public function open_follows_symlinks()
     {
         $file = $this->manager->open($this->dummy('mixed/another-dir/baz-link'));
 


### PR DESCRIPTION
Instead of displaying plain text error messages direct from PHP as the file's content, this PR replaces common errors with an icon and friendler message in a placeholder segment:

![image](https://user-images.githubusercontent.com/1521802/63478596-5ad1c400-c482-11e9-9bdb-43c518d7eed2.png)


Fixes #102 