### PR TITLE
Set path in File Manager URLs when switching folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Icons in the File Manager are now coloured based on type (file or folder)
 * Error handling when opening files in File Manager is greatly improved
 
+### Fixed
+* Path wouldn't update in File Manager URL while changing folders
+
 
 ## [0.3.0] - 2019-08-13
 ### Added

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -46,11 +46,11 @@ export default {
         },
         upOneLevel: function () {
             let path = this.currentPath;
-            let next = path.substr(0, path.lastIndexOf('/'))
+            let next = path.substr(0, path.lastIndexOf('/'));
+            next = next ? next : '/';
 
-            this.$store.dispatch('loadFiles', {
-                path: next ? next : '/'
-            });
+            this.$router.push({ name: 'files', params: { path: next } });
+            this.$store.dispatch('loadFiles', { path: next });
         },
     }
 }

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -39,10 +39,11 @@ export default {
     },
     methods: {
         setPath: function (file) {
-            this.$store.dispatch('loadFiles', {
-                path: this.currentPath == '/' ? '/' + file.filename
-                    : this.currentPath + '/' + file.filename
-            });
+            let path = this.currentPath == '/' ? '/' + file.filename
+                     : this.currentPath + '/' + file.filename
+
+            this.$router.push({ name: 'files', params: { path: path } });
+            this.$store.dispatch('loadFiles', { path: path });
         },
         upOneLevel: function () {
             let path = this.currentPath;


### PR DESCRIPTION
Before this PR if you went back from a file, browsed through a few folders then refreshed, you'd be back at whichever folder the file was in.

This tweaks the click handlers of file rows and the "up a level" button so that they update the URL to reflect the new file path every time the directory changes, meaning you can refresh at will without losing your place. Huzzah!

Fixes #99 