### PR TITLE
Fix domain validation rule for Sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Path wouldn't update in File Manager URL while changing folders
+* Domain name is now required when updating a Site
 
 
 ## [0.3.0] - 2019-08-13

--- a/app/Http/Requests/UpdateSite.php
+++ b/app/Http/Requests/UpdateSite.php
@@ -31,7 +31,7 @@ class UpdateSite extends FormRequest
                 'string',
                 Rule::unique('sites', 'name')->ignore($this->route('site')),
             ],
-            'primary_domain' => [new Domain],
+            'primary_domain' => ['required', new Domain],
             'type' => 'required|in:basic,php,laravel,redirect',
             'source_repo' => 'required_unless:type,redirect|nullable|url',
             'source_branch' => 'nullable|string',

--- a/app/Rules/Domain.php
+++ b/app/Rules/Domain.php
@@ -40,6 +40,6 @@ class Domain implements Rule
      */
     public function message()
     {
-        return ':attribute is not a valid FQDN.';
+        return 'The :attribute is not a valid FQDN.';
     }
 }


### PR DESCRIPTION
Makes the primary domain field required when updating a Site, and corrects the text of the error message.

Fixes #76 