### PR TITLE
Make segments of path bar clickable in File Browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Buttons to navigate between Sites and their files
+* CPU usage and current free RAM added to Stats Bar
 
 ### Changed
 * Icons in the File Manager are now coloured based on type (file or folder)
 * Error handling when opening files in File Manager is greatly improved
+* Segments in the File Browser's path bar will now jump to that path
 
 ### Fixed
 * Path wouldn't update in File Manager URL while changing folders

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -8,8 +8,8 @@
             <sui-button id="levelup" icon="level up" @click="upOneLevel"/>
 
             <sui-breadcrumb class="massive">
-                <template v-for="(part, index) in pathParts">
-                    <sui-breadcrumb-section>{{ part }}</sui-breadcrumb-section>
+                <template v-for="(segment, index) in pathParts">
+                    <sui-breadcrumb-section>{{ segment.dirname }}</sui-breadcrumb-section>
                     <sui-breadcrumb-divider v-if="index < (pathParts.length - 1)" />
                 </template>
             </sui-breadcrumb>
@@ -41,7 +41,13 @@ export default {
             'files',
         ]),
         pathParts: function() {
-            return this.currentPath.split('/');
+            let parts = [];
+
+            for (let part of this.currentPath.split('/')) {
+                parts.push({ 'dirname': part });
+            }
+
+            return parts;
         },
         site: function() {
             return this.getSiteByDocroot(this.currentPath);

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -4,8 +4,15 @@
             <router-link :to="{ name: 'apps.edit', params: { id: site.id }}"
                 is="sui-button" color="teal" icon="globe" floated="right"
                 id="back2site" :content="'Edit ' + site.name" v-if="site" />
-            <sui-button id="levelup" size="mini" icon="level up" @click="upOneLevel"/>
-            {{ currentPath }}
+
+            <sui-button id="levelup" icon="level up" @click="upOneLevel"/>
+
+            <sui-breadcrumb class="massive">
+                <template v-for="(part, index) in pathParts">
+                    <sui-breadcrumb-section>{{ part }}</sui-breadcrumb-section>
+                    <sui-breadcrumb-divider v-if="index < (pathParts.length - 1)" />
+                </template>
+            </sui-breadcrumb>
         </h2>
 
         <file-list :files="files" @set-path="setPath($event)" />
@@ -33,6 +40,9 @@ export default {
             'getSiteByDocroot',
             'files',
         ]),
+        pathParts: function() {
+            return this.currentPath.split('/');
+        },
         site: function() {
             return this.getSiteByDocroot(this.currentPath);
         },

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -8,10 +8,13 @@
             <sui-button id="levelup" icon="level up" @click="upOneLevel"/>
 
             <sui-breadcrumb class="massive">
-                <template v-for="(segment, index) in pathParts">
-                    <sui-breadcrumb-section>{{ segment.dirname }}</sui-breadcrumb-section>
+                <a is="router-link" :to="{ name: 'files', params: { path: segment.path }}"
+                   v-for="(segment, index) in pathParts" :key="segment.path">
+                    <sui-breadcrumb-section>
+                        {{ segment.dirname }}
+                    </sui-breadcrumb-section>
                     <sui-breadcrumb-divider v-if="index < (pathParts.length - 1)" />
-                </template>
+                </a>
             </sui-breadcrumb>
         </h2>
 
@@ -41,10 +44,16 @@ export default {
             'files',
         ]),
         pathParts: function() {
-            let parts = [];
+            let parts = [],
+                path = '';
 
             for (let part of this.currentPath.split('/')) {
-                parts.push({ 'dirname': part });
+                path = path + part + '/';
+
+                parts.push({
+                    'path': path.replace(/\/+$/, ''),
+                    'dirname': part,
+                });
             }
 
             return parts;

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -25,7 +25,7 @@
             </sui-breadcrumb>
         </h2>
 
-        <file-list :files="files" @set-path="setPathToFile($event)" />
+        <file-list :files="files" @set-path="setPath($event)" />
     </sui-container>
 </template>
 
@@ -74,17 +74,15 @@ export default {
         },
     },
     methods: {
-        setPath: function (path) {
-            path = '' == path ? '/' : path;
+        setPath: function (target) {
+            if (typeof target == 'string') {
+                target = '' == target ? '/' : target;
+            } else {
+                target = this.currentPath == '/' ? '/' + target.filename
+                     : this.currentPath + '/' + target.filename
+            }
 
-            this.$router.push({ name: 'files', params: { path: path } });
-        },
-        setPathToFile: function (file) {
-            let path = this.currentPath == '/' ? '/' + file.filename
-                     : this.currentPath + '/' + file.filename
-
-            this.$router.push({ name: 'files', params: { path: path } });
-            this.$store.dispatch('loadFiles', { path: path });
+            this.$router.push({ name: 'files', params: { path: target } });
         },
         upOneLevel: function () {
             let path = this.currentPath;

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -8,17 +8,17 @@
             <sui-button id="levelup" icon="level up" @click="upOneLevel"/>
 
             <sui-breadcrumb class="massive">
-                <a is="router-link" :to="{ name: 'files', params: { path: segment.path }}"
-                   v-for="(segment, index) in pathParts" :key="segment.path">
-                    <sui-breadcrumb-section>
+                <template v-for="(segment, index) in pathParts">
+                    <sui-breadcrumb-section link @click="setPath(segment.path)">
                         {{ segment.dirname }}
                     </sui-breadcrumb-section>
-                    <sui-breadcrumb-divider v-if="index < (pathParts.length - 1)" />
-                </a>
+                    <sui-breadcrumb-divider @click="setPath(segment.path)"
+                        v-if="index < (pathParts.length - 1)" />
+                </template>
             </sui-breadcrumb>
         </h2>
 
-        <file-list :files="files" @set-path="setPath($event)" />
+        <file-list :files="files" @set-path="setPathToFile($event)" />
     </sui-container>
 </template>
 
@@ -30,6 +30,10 @@ export default {
     mounted () {
         this.$store.dispatch('loadSites');
         this.$store.dispatch('loadFiles', { path: this.path });
+    },
+    beforeRouteUpdate (to, from, next) {
+        this.$store.dispatch('loadFiles', { path: to.params.path });
+        next();
     },
     props: [
         'path',
@@ -63,7 +67,12 @@ export default {
         },
     },
     methods: {
-        setPath: function (file) {
+        setPath: function (path) {
+            path = '' == path ? '/' : path;
+
+            this.$router.push({ name: 'files', params: { path: path } });
+        },
+        setPathToFile: function (file) {
             let path = this.currentPath == '/' ? '/' + file.filename
                      : this.currentPath + '/' + file.filename
 

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -9,11 +9,18 @@
 
             <sui-breadcrumb class="massive">
                 <template v-for="(segment, index) in pathParts">
-                    <sui-breadcrumb-section link @click="setPath(segment.path)">
+
+                    <sui-breadcrumb-section link @click="setPath(segment.path)"
+                        v-if="segment.path != currentPath">
                         {{ segment.dirname }}
                     </sui-breadcrumb-section>
+                    <sui-breadcrumb-section v-else>
+                        {{ segment.dirname }}
+                    </sui-breadcrumb-section>
+
                     <sui-breadcrumb-divider @click="setPath(segment.path)"
                         v-if="index < (pathParts.length - 1)" />
+
                 </template>
             </sui-breadcrumb>
         </h2>

--- a/resources/sass/_file-manager.scss
+++ b/resources/sass/_file-manager.scss
@@ -18,7 +18,7 @@
                 padding-left: 10px;
             }
         }
-        a.section {
+        .section {
             padding-left: 2px;
         }
     }

--- a/resources/sass/_file-manager.scss
+++ b/resources/sass/_file-manager.scss
@@ -6,6 +6,22 @@
 }
 
 #file-browser {
+    div.ui.breadcrumb {
+        div.divider {
+            color: #4183C4;
+            cursor: pointer;
+            padding: 0 1px 0 3px;
+            margin: 0 0 0 -4px;
+
+            &:first-of-type {
+                margin-left: -12px;
+                padding-left: 10px;
+            }
+        }
+        a.section {
+            padding-left: 2px;
+        }
+    }
     table.files {
         tbody > tr {
             cursor: pointer;


### PR DESCRIPTION
Converts the plain-text path to a list of breadcrumbs, each of which is formatted as a link and can now be clicked on to jump to that point in the filesystem.

The dividers are also clickable, with the first (root) divider having some extra padding to give it a bigger click target. The last segment is deliberately made unclickable - probably don't need to do anything if we're already there.

Closes #106 