### PR TITLE
Sites/error persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* When saving a Site you'll now see a success message
+
+### Fixed
+* Errors weren't being cleared between Site form submissions
 
 
 ## [0.4.0] - 2019-08-24

--- a/resources/js/components/Alerts.vue
+++ b/resources/js/components/Alerts.vue
@@ -1,0 +1,21 @@
+<template>
+    <div v-if="alerts.length" class="alerts">
+        <sui-message v-for="alert in alerts" :key="alert.message"
+                     :header="alert.title" v-if="alert.message"
+                     :success="alert.isSuccess" :error="!alert.isSuccess"
+                     class="visible">
+            <p>{{ alert.message }}</p>
+        </sui-message>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        alerts: {
+            type: Array,
+            default: () => ([]),
+        },
+    },
+}
+</script>

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -1,6 +1,6 @@
 <template>
     <sui-container>
-        <sui-form @submit.prevent="updateSite(tmpSite.id)" :error="error != ''">
+        <sui-form @submit.prevent="updateSite(tmpSite.id)">
             <sui-form-field class="enable-switch">
                 <sui-checkbox toggle v-model="tmpSite.is_enabled"/>
             </sui-form-field>
@@ -12,12 +12,7 @@
                 </sui-header-subheader>
             </h2>
 
-            <sui-message v-for="alert in alerts" :key="alert.message"
-                         :header="alert.title" v-if="alert.message"
-                         :success="alert.isSuccess" :error="!alert.isSuccess"
-                         class="visible">
-                <p>{{ alert.message }}</p>
-            </sui-message>
+            <alerts :alerts="alerts" />
 
             <sui-form-field :error="'name' in errors">
                 <label>App Name</label>
@@ -123,6 +118,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import Alerts from '../Alerts';
 
 export default {
     props: {
@@ -131,12 +127,13 @@ export default {
             default: () => ({}),
         },
     },
+    components: {
+        Alerts,
+    },
     computed: {
         ...mapState({
             'alerts': state => state.Site.alerts,
-            'error': state => state.Site.error,
             'errors': state => state.Site.errors,
-            'errorHeader': state => state.Site.error_title,
             'tmpSite': state => state.Site.current,
         }),
     },

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -12,8 +12,11 @@
                 </sui-header-subheader>
             </h2>
 
-            <sui-message error :header="errorHeader">
-                <p>{{ error }}</p>
+            <sui-message v-for="alert in alerts" :key="alert.message"
+                         :header="alert.title" v-if="alert.message"
+                         :success="alert.isSuccess" :error="!alert.isSuccess"
+                         class="visible">
+                <p>{{ alert.message }}</p>
             </sui-message>
 
             <sui-form-field :error="'name' in errors">
@@ -130,6 +133,7 @@ export default {
     },
     computed: {
         ...mapState({
+            'alerts': state => state.Site.alerts,
             'error': state => state.Site.error,
             'errors': state => state.Site.errors,
             'errorHeader': state => state.Site.error_title,

--- a/resources/js/pages/Sites/List.vue
+++ b/resources/js/pages/Sites/List.vue
@@ -1,18 +1,31 @@
 <template>
-    <sui-card-group>
-        <site-item v-for="site in sites" :key="site.id" :site="site"></site-item>
-    </sui-card-group>
+    <sui-container>
+        <alerts :alerts="alerts" />
+        <sui-card-group>
+            <site-item v-for="site in sites" :key="site.id" :site="site"></site-item>
+        </sui-card-group>
+    </sui-container>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+
+import Alerts from '../../components/Alerts';
 import SiteItem from '../../components/Sites/SiteItem';
 
 export default {
     components: {
+        Alerts,
         SiteItem,
     },
     props: [
         'sites',
     ],
+    computed: {
+        ...mapState({
+            alerts: state => state.Site.alerts,
+            errors: state => state.Site.errors,
+        }),
+    },
 }
 </script>

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -19,6 +19,11 @@ export default {
                 state.errors = errors;
             }
         },
+        clearErrors: state => {
+            state.error = '';
+            state.errors = [];
+            state.error_title = '';
+        },
         setFilter: (state, value) => {
             state.currentFilter = value;
         },
@@ -66,6 +71,7 @@ export default {
         createSite: ({commit, state}) => {
             axios.post('/api/sites', state.site).then(response => {
                 commit('addSite', response.data);
+                commit('clearErrors');
             });
         },
         updateSite: ({commit}, site) => {
@@ -74,6 +80,7 @@ export default {
                     id: site.id,
                     site: response.data
                 });
+                commit('clearErrors');
             }).catch(error => {
                 const res = error.response;
 

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -80,7 +80,7 @@ export default {
             axios.post('/api/sites', state.site).then(response => {
                 commit('addSite', response.data);
                 commit('clearMessages');
-                commit('setSuccess', "The site '" + site.name + "' has been created.");
+                commit('setSuccess', "The site '" + response.data.name + "' has been created.");
             });
         },
         updateSite: ({commit}, site) => {

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -1,10 +1,9 @@
 export default {
     state: {
+        alerts: [],
         current: {},
         currentFilter: '',
-        error: '',
         errors: [],
-        error_title: '',
         sites: [],
         site: {
             name: '',
@@ -12,17 +11,19 @@ export default {
     },
     mutations: {
         setErrors: (state, {message, errors, action = 'save'}) => {
-            state.error = message;
-            state.error_title = 'Could not ' + action + ' Site!';
+            state.alerts.push({
+                title: 'Could not ' + action + ' Site!',
+                message: message,
+                isSuccess: false,
+            });
 
             if (errors) {
                 state.errors = errors;
             }
         },
         clearErrors: state => {
-            state.error = '';
+            state.alerts = [];
             state.errors = [];
-            state.error_title = '';
         },
         setFilter: (state, value) => {
             state.currentFilter = value;

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -84,6 +84,7 @@ export default {
                 commit('clearErrors');
             }).catch(error => {
                 const res = error.response;
+                commit('clearErrors');
 
                 if (res && res.status === 422) {
                     commit('setErrors', {

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -10,6 +10,13 @@ export default {
         },
     },
     mutations: {
+        setSuccess: (state, message) => {
+            state.alerts.push({
+                title: 'Success!',
+                message: message,
+                isSuccess: true,
+            });
+        },
         setErrors: (state, {message, errors, action = 'save'}) => {
             state.alerts.push({
                 title: 'Could not ' + action + ' Site!',
@@ -21,7 +28,7 @@ export default {
                 state.errors = errors;
             }
         },
-        clearErrors: state => {
+        clearMessages: state => {
             state.alerts = [];
             state.errors = [];
         },
@@ -72,19 +79,21 @@ export default {
         createSite: ({commit, state}) => {
             axios.post('/api/sites', state.site).then(response => {
                 commit('addSite', response.data);
-                commit('clearErrors');
+                commit('clearMessages');
+                commit('setSuccess', "The site '" + site.name + "' has been created.");
             });
         },
         updateSite: ({commit}, site) => {
             axios.put('/api/sites/'+site.id, site.data).then(response => {
+                commit('clearMessages');
                 commit('updateSite', {
                     id: site.id,
                     site: response.data
                 });
-                commit('clearErrors');
+                commit('setSuccess', "The site '" + site.data.name + "' has been saved.");
             }).catch(error => {
                 const res = error.response;
-                commit('clearErrors');
+                commit('clearMessages');
 
                 if (res && res.status === 422) {
                     commit('setErrors', {

--- a/resources/sass/_alerts.scss
+++ b/resources/sass/_alerts.scss
@@ -1,0 +1,3 @@
+.alerts {
+    margin-bottom: 1em;
+}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,6 +1,7 @@
 @import 'variables';
 @import '~semantic-ui-sass/semantic-ui';
 
+@import 'alerts';
 @import 'footer';
 
 @import 'file-manager';


### PR DESCRIPTION
Solve an issue where form errors would stick beyond resubmissions, and adds support to the Sites/Applications section for showing success messages when creating/saving sites.

Fixes #87 