### PR TITLE
Update stats bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * When saving a Site you'll now see a success message
+* Disk usage of the root mountpoint is now shown in Stats Bar
 
 ### Changed
 * Main layout and stats bar completely redesigned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * When saving a Site you'll now see a success message
 * Disk usage of the root mountpoint is now shown in Stats Bar
+* Load average is also now displayed in Stats Bar
 
 ### Changed
 * Main layout and stats bar completely redesigned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * When saving a Site you'll now see a success message
 * Disk usage of the root mountpoint is now shown in Stats Bar
-* Load average is also now displayed in Stats Bar
+* Extra information added in tooltips on the stats bar items
 
 ### Changed
 * Main layout and stats bar completely redesigned

--- a/app/StatsBar.php
+++ b/app/StatsBar.php
@@ -59,7 +59,7 @@ class StatsBar
         return [
             'total' => round($data[1] / 1024),
             'used' => round($data[2] / 1024),
-            'free' => round(($data[3] + $data[5]) / 1024),
+            'free' => round((round($data[3]) + round($data[5])) / 1024),
         ];
     }
 

--- a/app/StatsBar.php
+++ b/app/StatsBar.php
@@ -11,6 +11,7 @@ class StatsBar
 
         return [
             'cpu' => self::getCpuUsage(),
+            'load_average' => self::getLoadAverage(),
             'ram' => self::getRamUsage(),
             'disk' => self::getDiskUsage(),
             'hostname' => gethostname(),
@@ -45,6 +46,20 @@ class StatsBar
     private static function getCpuUsage(): float
     {
         return (float) exec("mpstat | tail -n1 | awk '{ print 100 - $12 }'");
+    }
+
+    /**
+     * Get the CPU load average over 1, 5 and 15 minute intervals.
+     */
+    private static function getLoadAverage(): array
+    {
+        $output = explode(' ', exec('awk \'{ print $1,$2,$3; }\' /proc/loadavg'));
+
+        return [
+            '1m' => $output[0],
+            '5m' => $output[1],
+            '15m' => $output[2],
+        ];
     }
 
     /**

--- a/app/StatsBar.php
+++ b/app/StatsBar.php
@@ -12,6 +12,7 @@ class StatsBar
         return [
             'cpu' => self::getCpuUsage(),
             'ram' => self::getRamUsage(),
+            'disk' => self::getDiskUsage(),
             'hostname' => gethostname(),
             'os' => [
                 'name' => php_uname('s'),
@@ -59,6 +60,24 @@ class StatsBar
             'total' => round($data[1] / 1024),
             'used' => round($data[2] / 1024),
             'free' => round(($data[3] + $data[5]) / 1024),
+        ];
+    }
+
+    /**
+     * Get the disk usage details for the root mountpoint.
+     */
+    private static function getDiskUsage(): array
+    {
+        $output = exec('df | grep " /$"');
+
+        $data = sscanf($output, '%s %d %d %d %s %s');
+
+        return [
+            'partition' => $data[0],
+            'total' => number_format($data[1] / 1024 / 1024, 1),
+            'used' => number_format($data[2] / 1024 / 1024, 1),
+            'used_pct' => $data[4],
+            'free' => number_format($data[3] / 1024 / 1024, 1),
         ];
     }
 }

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -13,22 +13,12 @@
         </sui-menu-item>
         <sui-menu-menu position="right">
         <sui-menu-item>
-            <sui-statistic size="mini">
+            <sui-statistic size="mini" :data-tooltip="cpuTooltip()" data-position="bottom center">
                 <sui-statistic-label>
                     <sui-icon name="tachometer alternate" /> CPU Usage
                 </sui-statistic-label>
                 <sui-statistic-value>
-                    {{ cpu_usage }}%
-                </sui-statistic-value>
-            </sui-statistic>
-        </sui-menu-item>
-        <sui-menu-item>
-            <sui-statistic size="mini" :data-tooltip="loadAvgTooltip()" data-position="bottom center">
-                <sui-statistic-label>
-                    <sui-icon name="history" /> Load Avg.
-                </sui-statistic-label>
-                <sui-statistic-value>
-                    {{ load_avg['5m'] }} (5m)
+                    {{ cpu_usage }}% ({{ load_avg['5m'] }})
                 </sui-statistic-value>
             </sui-statistic>
         </sui-menu-item>
@@ -86,10 +76,9 @@ export default {
                 this.loaded = true;
             });
         },
-        loadAvgTooltip () {
-            return this.load_avg['1m'] + ' / ' +
-                    this.load_avg['5m'] + ' / ' +
-                    this.load_avg['15m'] + ' (1m / 5m / 15m)';
+        cpuTooltip () {
+            return 'Load average: ' + this.load_avg['1m'] + ', '
+                 + this.load_avg['5m'] + ', ' + this.load_avg['15m'];
         },
         ramTooltip () {
             return 'Using ' + this.ram.used + 'M of ' + this.ram.total + 'M';

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -11,6 +11,7 @@
                 </sui-statistic-label>
             </sui-statistic>
         </sui-menu-item>
+        <sui-menu-menu position="right">
         <sui-menu-item>
             <sui-statistic size="mini">
                 <sui-statistic-label>
@@ -42,6 +43,7 @@
                 </sui-statistic-value>
             </sui-statistic>
         </sui-menu-item>
+        </sui-menu-menu>
     </sui-menu>
 </template>
 

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -23,7 +23,7 @@
             </sui-statistic>
         </sui-menu-item>
         <sui-menu-item>
-            <sui-statistic size="mini">
+            <sui-statistic size="mini" :data-tooltip="loadAvgTooltip()" data-position="bottom center">
                 <sui-statistic-label>
                     <sui-icon name="history" /> Load Avg.
                 </sui-statistic-label>
@@ -33,23 +33,23 @@
             </sui-statistic>
         </sui-menu-item>
         <sui-menu-item>
-            <sui-statistic size="mini">
+            <sui-statistic size="mini" :data-tooltip="ramTooltip()" data-position="bottom center">
                 <sui-statistic-label>
                     <sui-icon name="microchip" /> Free RAM
                 </sui-statistic-label>
                 <sui-statistic-value>
-                    {{ ram.free }}MB
+                    {{ ram.free }}M
                 </sui-statistic-value>
             </sui-statistic>
         </sui-menu-item>
         <sui-menu-item>
-            <sui-statistic size="mini">
+            <sui-statistic size="mini" :data-tooltip="diskTooltip()" data-position="bottom center">
                 <sui-statistic-label>
                     <sui-icon name="disk" /> {{ disk.partition }} Usage
                 </sui-statistic-label>
                 <sui-statistic-value>
                     <!-- {{ disk.free }}MB -->
-                    {{ disk.used_pct }} of {{ disk.total }}GB
+                    {{ disk.used_pct }} of {{ disk.total }}G
                 </sui-statistic-value>
             </sui-statistic>
         </sui-menu-item>
@@ -85,6 +85,17 @@ export default {
 
                 this.loaded = true;
             });
+        },
+        loadAvgTooltip () {
+            return this.load_avg['1m'] + ' / ' +
+                    this.load_avg['5m'] + ' / ' +
+                    this.load_avg['15m'] + ' (1m / 5m / 15m)';
+        },
+        ramTooltip () {
+            return 'Using ' + this.ram.used + 'M of ' + this.ram.total + 'M';
+        },
+        diskTooltip () {
+            return this.disk.used + 'G used; ' + this.disk.free + 'G free' ;
         },
     },
 }

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -12,7 +12,6 @@
             </sui-statistic>
         </sui-menu-item>
         <sui-menu-item>
-            <!-- todo: add hdd  -->
             <sui-statistic size="mini">
                 <sui-statistic-label>
                     <sui-icon name="tachometer alternate" /> CPU Usage
@@ -29,6 +28,17 @@
                 </sui-statistic-label>
                 <sui-statistic-value>
                     {{ ram.free }}MB
+                </sui-statistic-value>
+            </sui-statistic>
+        </sui-menu-item>
+        <sui-menu-item>
+            <sui-statistic size="mini">
+                <sui-statistic-label>
+                    <sui-icon name="disk" /> {{ disk.partition }} Usage
+                </sui-statistic-label>
+                <sui-statistic-value>
+                    <!-- {{ disk.free }}MB -->
+                    {{ disk.used_pct }} of {{ disk.total }}GB
                 </sui-statistic-value>
             </sui-statistic>
         </sui-menu-item>
@@ -56,6 +66,7 @@ export default {
                 this.hostname = data.hostname;
                 this.cpu_usage = data.cpu;
                 this.ram = data.ram;
+                this.disk = data.disk;
                 this.distro = data.os.distro;
                 this.version = data.os.version;
 

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -25,6 +25,16 @@
         <sui-menu-item>
             <sui-statistic size="mini">
                 <sui-statistic-label>
+                    <sui-icon name="history" /> Load Avg.
+                </sui-statistic-label>
+                <sui-statistic-value>
+                    {{ load_avg['5m'] }} (5m)
+                </sui-statistic-value>
+            </sui-statistic>
+        </sui-menu-item>
+        <sui-menu-item>
+            <sui-statistic size="mini">
+                <sui-statistic-label>
                     <sui-icon name="microchip" /> Free RAM
                 </sui-statistic-label>
                 <sui-statistic-value>
@@ -67,6 +77,7 @@ export default {
 
                 this.hostname = data.hostname;
                 this.cpu_usage = data.cpu;
+                this.load_avg = data.load_average;
                 this.ram = data.ram;
                 this.disk = data.disk;
                 this.distro = data.os.distro;

--- a/tests/Unit/StatsBarTest.php
+++ b/tests/Unit/StatsBarTest.php
@@ -23,6 +23,12 @@ class StatsBarTest extends TestCase
         $this->assertArrayHasKey('used', $data['ram']);
         $this->assertArrayHasKey('free', $data['ram']);
 
+        $this->assertArrayHasKey('disk', $data);
+        $this->assertIsArray($data['disk']);
+        $this->assertArrayHasKey('total', $data['disk']);
+        $this->assertArrayHasKey('used', $data['disk']);
+        $this->assertArrayHasKey('free', $data['disk']);
+
         $this->assertArrayHasKey('hostname', $data);
         $this->assertIsString($data['hostname']);
 
@@ -50,7 +56,7 @@ class StatsBarTest extends TestCase
     }
 
     /** @test */
-    public function free_memory_matches_total_minus_used_memory()
+    public function free_memory_matches_total_minus_used()
     {
         $data = StatsBar::stats()['ram'];
 

--- a/tests/Unit/StatsBarTest.php
+++ b/tests/Unit/StatsBarTest.php
@@ -17,6 +17,12 @@ class StatsBarTest extends TestCase
         $this->assertArrayHasKey('cpu', $data);
         $this->assertIsFloat($data['cpu']);
 
+        $this->assertArrayHasKey('load_average', $data);
+        $this->assertIsArray($data['load_average']);
+        $this->assertArrayHasKey('1m', $data['load_average']);
+        $this->assertArrayHasKey('5m', $data['load_average']);
+        $this->assertArrayHasKey('15m', $data['load_average']);
+
         $this->assertArrayHasKey('ram', $data);
         $this->assertIsArray($data['ram']);
         $this->assertArrayHasKey('total', $data['ram']);


### PR DESCRIPTION
Adds disk usage item showing the root mountpoint and percent used of total. Also pulls the stats (except hostname/distro, which isn't really a stat) to the right to make it slightly easier on the eyes.