### PR TITLE
Add tooltip with textual permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When saving a Site you'll now see a success message
 * Disk usage of the root mountpoint is now shown in Stats Bar
 * Extra information added in tooltips on the stats bar items
+* File browser now shows `-rwxrw-rw-` form permissions in a tooltip
 
 ### Changed
 * Main layout and stats bar completely redesigned

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -86,9 +86,13 @@ class FileManager
             'group' => posix_getgrgid($file->getGroup())['name'],
         ];
 
-        $data['perms'] = in_array($data['filename'], $this->file_perms)
-                                 ? $this->file_perms[$data['filename']]
-                                 : mb_substr(decoct($file->getPerms()), -4);
+        $data['perms'] = is_null($this->file_perms) || !isset($this->file_perms[$data['filename']])
+                       ? ['text' => '', 'octal' => mb_substr(decoct($file->getPerms()), -4)]
+                       : $this->file_perms[$data['filename']];
+
+        if (3 === mb_strlen($data['perms']['octal'])) {
+            $data['perms']['octal'] = '0'.$data['perms']['octal'];
+        }
 
         if ($includeContents) {
             try {

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -56,7 +56,7 @@ class FileManager
     {
         $perms = [];
 
-        exec("stat -c '%n %A %a' ${path}/*", $files);
+        exec('cd "'.$path.'" && stat -c "%n %A %a" *', $files);
 
         foreach ($files as $file) {
             list($filename, $text, $octal) = explode(' ', $file);

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -56,7 +56,7 @@ class FileManager
 
     private function loadPermissions(string $path, bool $isFile = false): array
     {
-        $name = '*';
+        $name = '.* *';
         $perms = [];
 
         if ($isFile) {

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -49,14 +49,23 @@ class FileManager
             return ['error' => ['code' => 404, 'msg' => 'File not found']];
         }
 
+        $this->loadPermissions($file, true);
+
         return $this->fileToArray($file, true);
     }
 
-    private function loadPermissions($path)
+    private function loadPermissions(string $path, bool $isFile = false): array
     {
+        $name = '*';
         $perms = [];
 
-        exec('cd "'.$path.'" && stat -c "%n %A %a" *', $files);
+        if ($isFile) {
+            $pathParts = explode('/', $path);
+            $name = array_pop($pathParts);
+            $path = mb_substr($path, 0, mb_strrpos($path, '/'));
+        }
+
+        exec('cd "'.$path.'" && stat -c "%n %A %a" '.$name, $files);
 
         foreach ($files as $file) {
             list($filename, $text, $octal) = explode(' ', $file);
@@ -64,7 +73,7 @@ class FileManager
             $perms[$filename] = compact('text', 'octal');
         }
 
-        $this->file_perms = $perms;
+        return $this->file_perms = $perms;
     }
 
     private function fileToArray($file, $includeContents = false): array

--- a/resources/js/components/Files/Browser/FileRow.vue
+++ b/resources/js/components/Files/Browser/FileRow.vue
@@ -6,7 +6,8 @@
                 <sui-icon name="alternate long arrow right" /> {{ file.target }}
             </span>
         </sui-table-cell>
-        <td>{{ file.perms }}</td>
+        <sui-table-cell :data-tooltip="file.perms.text" data-position="right center"
+            collapsing>{{ file.perms.octal }}</sui-table-cell>
         <td>{{ file.owner }}</td>
         <td>{{ file.group }}</td>
     </tr>

--- a/tests/Unit/FileManager/FileManagerTest.php
+++ b/tests/Unit/FileManager/FileManagerTest.php
@@ -149,7 +149,7 @@ class FileManagerTest extends TestCase
             'owner' => 'www-data',
             'group' => 'www-data',
             'perms' => [
-                'text' => '',
+                'text' => '-rw-rw-r--',
                 'octal' => '0664',
             ],
         ], $file);

--- a/tests/Unit/FileManager/FileManagerTest.php
+++ b/tests/Unit/FileManager/FileManagerTest.php
@@ -65,6 +65,18 @@ class FileManagerTest extends TestCase
     }
 
     /** @test */
+    public function permissions_are_loaded_for_hidden_files()
+    {
+        $list = $this->manager->list($this->dummy('hidden'));
+
+        $this->assertCount(3, $list);
+        $this->assertEquals([
+            'text' => '-rw-rw-r--',
+            'octal' => '0664',
+        ], $list[0]['perms']);
+    }
+
+    /** @test */
     public function list_can_show_files_in_system_root()
     {
         $list = $this->manager->list('/');

--- a/tests/Unit/FileManager/FileManagerTest.php
+++ b/tests/Unit/FileManager/FileManagerTest.php
@@ -33,7 +33,10 @@ class FileManagerTest extends TestCase
             'target' => '',
             'owner' => 'www-data',
             'group' => 'www-data',
-            'perms' => '0775',
+            'perms' => [
+                'text' => 'drwxrwxr-x',
+                'octal' => '0775',
+            ],
         ], $list[0]);
     }
 
@@ -77,7 +80,10 @@ class FileManagerTest extends TestCase
             'isFile' => false,
             'owner' => 'root',
             'group' => 'root',
-            'perms' => '0755',
+            'perms' => [
+                'text' => 'drwxr-xr-x',
+                'octal' => '0755',
+            ],
         ];
 
         $this->assertCount(5, $matches);
@@ -142,7 +148,10 @@ class FileManagerTest extends TestCase
             'target' => '',
             'owner' => 'www-data',
             'group' => 'www-data',
-            'perms' => '0664',
+            'perms' => [
+                'text' => '',
+                'octal' => '0664',
+            ],
         ], $file);
     }
 


### PR DESCRIPTION
Octal form is still the default form shown in the file list, but now if you hover over it you'll get the textual *rwxrw-rw-* form in a tooltip.

Also normalises the octal forms to all be 4 digits. The mix of 3 and 4 digit permission strings was looking messy.

Closes #101 