### PR TITLE
Site Details page with ability to trigger `git pull`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /public/js/app.js
 /public/hot
 /public/storage
+/storage/test-clone
 /storage/*.key
 /vendor
 /.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Disk usage of the root mountpoint is now shown in Stats Bar
 * Extra information added in tooltips on the stats bar items
 * File browser now shows `-rwxrw-rw-` form permissions in a tooltip
+* Site files can now be updated from a new details page
 
 ### Changed
 * Main layout and stats bar completely redesigned

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -59,17 +59,19 @@ class SiteController extends Controller
         if (is_dir($root . '/.git')) {
             $args = $branch ? ' && git checkout "' . $branch . '"' : '';
 
-            $cmd = 'cd "' . $root . '"' . $args . ' && git pull';
-        } else {
-            if (!is_dir(dirname($root))) {
-                mkdir(dirname($root));
-            }
+            exec('cd "' . $root . '"' . $args . ' && git pull');
 
-            $args = $branch ? ' --branch "' . $branch . '"' : '';
-            $paths = ' "' . $site->source_repo . '" "' . $root . '"';
-
-            $cmd = 'git clone' . $args . $paths;
+            return response($site, Response::HTTP_OK);
         }
+
+        if (!is_dir(dirname($root))) {
+            mkdir(dirname($root));
+        }
+
+        $args = $branch ? ' --branch "' . $branch . '"' : '';
+        $paths = ' "' . $site->source_repo . '" "' . $root . '"';
+
+        $cmd = 'git clone' . $args . $paths;
 
         exec($cmd);
 

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -100,7 +100,7 @@
             <sui-button negative icon="trash" type="button"
                 content="Delete" floated="right" @click="deleteSite(site.id)" />
             <sui-button-group>
-                <router-link :to="{ name: 'apps' }" is="sui-button"
+                <router-link :to="{ name: 'apps.view', params: { id: site.id } }" is="sui-button"
                     type="button" content="Cancel" />
                 <sui-button-or />
                 <sui-button type="submit" positive content="Save" />

--- a/resources/js/components/Sites/SiteItem.vue
+++ b/resources/js/components/Sites/SiteItem.vue
@@ -6,9 +6,6 @@
         </sui-card-content>
 
         <sui-card-content extra>
-            <router-link :to="{ name: 'apps.edit', params: { id: site.id } }">
-                <sui-icon name="cogs"></sui-icon> Manage Site
-            </router-link>
             <router-link :to="{ name: 'files', params: { path: site.document_root } }"
                 slot="right" v-if="site.document_root != null">
                 <sui-icon name="open folder" /> Browse Files

--- a/resources/js/components/Sites/SiteItem.vue
+++ b/resources/js/components/Sites/SiteItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-card>
+    <router-link is="sui-card" :to="{ name: 'apps.view', params: { id: site.id } }">
         <sui-card-content>
             <sui-card-header>{{ site.name }}</sui-card-header>
             <sui-card-meta>{{ site.primary_domain }}</sui-card-meta>
@@ -14,7 +14,7 @@
                 <sui-icon name="open folder" /> Browse Files
             </router-link>
         </sui-card-content>
-    </sui-card>
+    </router-link>
 </template>
 
 <script>

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -2,9 +2,11 @@
     <sui-grid container>
         <sui-grid-column id="file-browser">
             <h2>
-                <router-link :to="{ name: 'apps.edit', params: { id: site.id }}"
+                <router-link :to="{ name: 'apps.view', params: { id: site.id }}"
                     is="sui-button" color="teal" icon="globe" floated="right"
-                    id="back2site" :content="'Edit ' + site.name" v-if="site" />
+                    id="back2site" content="View Application" v-if="site"
+                    :data-tooltip="'Open overview for ' + site.name"
+                    data-position="left center" />
 
                 <sui-button id="levelup" icon="level up" @click="upOneLevel" />
 

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -32,6 +32,8 @@
                         </sui-grid-column>
                         <sui-grid-column>
                             <sui-header size="tiny"> Tracking Branch
+                                <sui-button basic positive icon="download" floated="right"
+                                    content="Pull Latest Code" @click="pullFiles(site)" />
                                 <sui-header-subheader v-if="site.source_branch">
                                     {{ site.source_branch }}
                                 </sui-header-subheader>
@@ -83,8 +85,8 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex';
 import SiteItem from '../../components/Sites/SiteItem';
-import store from '../../store';
 
 export default {
     components: {
@@ -101,6 +103,11 @@ export default {
         site(){
             return this.sites.find(s => s.id === this.id);
         },
+    },
+    methods: {
+        ...mapActions({
+            pullFiles: 'pullSiteFiles',
+        }),
     },
 }
 </script>

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -18,11 +18,30 @@
 
             <sui-header attached="top">Source Files</sui-header>
             <sui-segment attached>
-                <sui-header size="tiny" v-if="site.source_repo">
-                    Repository Clone URL
-                    <sui-header-subheader>{{ site.source_repo }}</sui-header-subheader>
-                </sui-header>
-                <p v-else>No source repository has been set for this project!</p>
+                <sui-grid>
+                    <sui-grid-row :columns="2">
+                        <sui-grid-column>
+                            <sui-header size="tiny"> Repository Clone URL
+                                <sui-header-subheader v-if="site.source_repo">
+                                    {{ site.source_repo }}
+                                </sui-header-subheader>
+                                <sui-header-subheader v-else>
+                                    No source repository has been set for this project!
+                                </sui-header-subheader>
+                            </sui-header>
+                        </sui-grid-column>
+                        <sui-grid-column>
+                            <sui-header size="tiny"> Tracking Branch
+                                <sui-header-subheader v-if="site.source_branch">
+                                    {{ site.source_branch }}
+                                </sui-header-subheader>
+                                <sui-header-subheader v-else>
+                                    Using default branch
+                                </sui-header-subheader>
+                            </sui-header>
+                        </sui-grid-column>
+                    </sui-grid-row>
+                </sui-grid>
 
                 <sui-header size="tiny" v-if="site.document_root">
                     <router-link :to="{ name: 'files', params: {path: site.document_root } }"

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -1,0 +1,58 @@
+<template>
+    <sui-grid-row>
+        <sui-grid-column :width=4>
+            <sui-card-group>
+                <site-item v-for="site in sites" :key="site.id" :site="site"></site-item>
+            </sui-card-group>
+        </sui-grid-column>
+        <sui-grid-column :width=12>
+            <h2 is="sui-header" size="huge">
+                {{ site.name }}
+                <sui-header-subheader>
+                    {{ site.primary_domain }}
+                </sui-header-subheader>
+            </h2>
+
+            <sui-header attached="top">Source Files</sui-header>
+            <sui-segment attached>
+                <sui-header size="tiny" v-if="site.source_repo">
+                    Repository Clone URL
+                    <sui-header-subheader>{{ site.source_repo }}</sui-header-subheader>
+                </sui-header>
+                <p v-else>No source repository has been set for this project!</p>
+
+                <sui-header size="tiny" v-if="site.document_root">
+                    <router-link :to="{ name: 'files', params: {path: site.document_root } }"
+                                 content="Browse files" is="sui-button" floated="right"
+                                 basic primary icon="open folder" />
+                    Document Root
+                    <sui-header-subheader>{{ site.document_root }}</sui-header-subheader>
+                </sui-header>
+                <p v-else>This project doesn't have a document root defined.</p>
+            </sui-segment>
+        </sui-grid-column>
+    </sui-grid-row>
+</template>
+
+<script>
+import SiteItem from '../../components/Sites/SiteItem';
+import store from '../../store';
+
+export default {
+    components: {
+        SiteItem,
+    },
+    props: {
+        id: {
+            type: Number,
+            default: 0,
+        },
+        sites: Array,
+    },
+    computed: {
+        site(){
+            return this.sites.find(s => s.id === this.id);
+        },
+    },
+}
+</script>

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -7,6 +7,9 @@
         </sui-grid-column>
         <sui-grid-column :width=12>
             <h2 is="sui-header" size="huge">
+                <router-link :to="{ name: 'apps.edit', params: { id: site.id } }"
+                             content="Manage Site" is="sui-button" floated="right"
+                             color="teal" icon="cogs" size="large" />
                 {{ site.name }}
                 <sui-header-subheader>
                     {{ site.primary_domain }}

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -52,6 +52,32 @@
                 </sui-header>
                 <p v-else>This project doesn't have a document root defined.</p>
             </sui-segment>
+
+            <sui-header v-if="site.type == 'redirect'" attached="top">Redirection</sui-header>
+            <sui-segment v-if="site.type == 'redirect'" attached>
+                <sui-grid>
+                    <sui-grid-row :columns="2">
+                        <sui-grid-column>
+                            <sui-header size="tiny"> Target URL
+                                <sui-header-subheader>{{ site.redirect_to }}</sui-header-subheader>
+                            </sui-header>
+                        </sui-grid-column>
+                        <sui-grid-column>
+                            <sui-header size="tiny"> Redirect Type
+                                <sui-header-subheader v-if="site.redirect_type == 301">
+                                    Permanent
+                                </sui-header-subheader>
+                                <sui-header-subheader v-else-if="site.redirect_type == 302">
+                                    Temporary
+                                </sui-header-subheader>
+                                <sui-header-subheader v-else>
+                                    {{ site.redirect_type }}
+                                </sui-header-subheader>
+                            </sui-header>
+                        </sui-grid-column>
+                    </sui-grid-row>
+                </sui-grid>
+            </sui-segment>
         </sui-grid-column>
     </sui-grid-row>
 </template>

--- a/resources/js/routes.js
+++ b/resources/js/routes.js
@@ -5,6 +5,7 @@ import FileEditor from './pages/Files/Editor.vue'
 import Sites from './pages/Sites.vue'
 import SiteList from './pages/Sites/List.vue'
 import SiteEditor from './pages/Sites/Edit.vue'
+import SiteViewer from './pages/Sites/Detail.vue'
 import SystemGroups from './components/System/Groups.vue'
 import SystemUsers from './components/System/Users.vue'
 import Layout from './layouts/Servidor.vue'
@@ -27,9 +28,23 @@ const routes = [{
             path: '/',
             meta: { auth: true },
         }, {
+            component: SiteViewer,
+            name: 'apps.view',
+            path: '/apps/:id',
+            meta: { auth: true },
+            props: (route) => {
+                let id = parseInt(route.params.id);
+
+                if (Number.isNaN(id) || id < 0) {
+                    return { id: 0 };
+                }
+
+                return { id: id };
+            },
+        }, {
             component: SiteEditor,
             name: 'apps.edit',
-            path: '/apps/:id',
+            path: '/apps/:id/edit',
             meta: { auth: true },
             props: (route) => {
                 let id = parseInt(route.params.id);

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -107,6 +107,9 @@ export default {
                 }
             });
         },
+        pullSiteFiles: ({commit, state}, site) => {
+            return axios.post('/api/sites/'+site.id+'/pull');
+        },
         deleteSite: ({commit, state}, id) => {
             return new Promise((resolve, reject) => {
                 axios.delete('/api/sites/' + id).then(response => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::middleware('auth:api')->group(function () {
     Route::resource('sites', 'SiteController', [
         'only' => ['index', 'store', 'update', 'destroy'],
     ]);
+    Route::post('sites/{site}/pull', 'SiteController@pull');
 
     Route::resource('files', 'FileController', [
         'only' => ['index'],

--- a/tests/Feature/Api/SitesTest.php
+++ b/tests/Feature/Api/SitesTest.php
@@ -179,17 +179,25 @@ class SitesApiTest extends TestCase
     /** @test */
     public function authed_user_can_pull_site_files()
     {
+        // This would ideally be inside resources/test-skel somewhere, but
+        // for some reason Travis has permission issues creating in there.
+        $dir = storage_path('test-clone');
+
         $site = Site::create([
             'name' => 'Dummy Site',
             'type' => 'basic',
-            'document_root' => 'resources/test-skel/www',
+            'document_root' => $dir,
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
         ]);
 
         $response = $this->authed()->postJson('/api/sites/' . $site->id . '/pull');
 
         $response->assertOk();
-        $this->assertDirectoryExists('resources/test-skel/www/.git');
+        $this->assertDirectoryExists($dir . '/.git');
+
+        // If we try this in tearDown(), storage_path() complains that
+        // path.storage class can't be found. No idea why, but it does.
+        exec('rm -rf "' . $dir . '"');
     }
 
     /** @test */

--- a/tests/Feature/Api/SitesTest.php
+++ b/tests/Feature/Api/SitesTest.php
@@ -156,6 +156,73 @@ class SitesApiTest extends TestCase
         $response->assertJsonMissingValidationErrors(['name']);
     }
 
+    /**
+     * @test
+     * @depends authed_user_can_list_sites
+     */
+    public function guest_cannot_pull_site_files()
+    {
+        $site = Site::create([
+            'name' => 'Dummy Site',
+            'type' => 'basic',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+
+        $response = $this->postJson('/api/sites/' . $site->id . '/pull');
+
+        $response->assertJsonCount(1);
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+        $response->assertJson(['message' => 'Unauthenticated.']);
+        $this->assertArraySubset($site->toArray(), Site::first()->toArray());
+    }
+
+    /** @test */
+    public function authed_user_can_pull_site_files()
+    {
+        $site = Site::create([
+            'name' => 'Dummy Site',
+            'type' => 'basic',
+            'document_root' => 'resources/test-skel/www',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+
+        $response = $this->authed()->postJson('/api/sites/' . $site->id . '/pull');
+
+        $response->assertOk();
+        $this->assertDirectoryExists('resources/test-skel/www/.git');
+    }
+
+    /** @test */
+    public function cannot_pull_site_when_type_is_redirect()
+    {
+        $site = Site::create([
+            'name' => 'Primed for deletion',
+            'type' => 'redirect',
+        ]);
+
+        $response = $this->authed()->postJson('/api/sites/' . $site->id . '/pull');
+
+        $response->assertJsonCount(1);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJson(['error' => 'Project type does not support pull.']);
+    }
+
+    /** @test */
+    public function cannot_pull_site_when_missing_document_root()
+    {
+        $site = Site::create([
+            'name' => 'Dummy Site',
+            'type' => 'basic',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+
+        $response = $this->authed()->postJson('/api/sites/' . $site->id . '/pull');
+
+        $response->assertJsonCount(1);
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJson(['error' => 'Project is missing its document root!']);
+    }
+
     /** @test */
     public function guest_cannot_delete_site()
     {


### PR DESCRIPTION
Finally, we have a way to pull from Git without making some change so that it triggers the save events. Adds a details page to act as a dashboard of sorts, and updates links in the site list and file browser to go here instead of the editor.

![image](https://user-images.githubusercontent.com/1521802/65797607-8b82d880-e167-11e9-9765-e6f5f04d9b3a.png)

Closes #91 