### PR TITLE
Namespace the VueX modules to isolate searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Login is now enforced correctly when auth tokens change or expire
 * Clearing search now works again for System users and groups
 * Errors preventing System user/group creation are resolved
+* Filtering Sites/Users/Groups no longer affects other pages
 
 
 ## [0.4.0] - 2019-08-24

--- a/resources/js/components/Files/Browser/FileList.vue
+++ b/resources/js/components/Files/Browser/FileList.vue
@@ -27,9 +27,9 @@ export default {
         FileRow,
     },
     computed: {
-        ...mapGetters([
-            'currentPath',
-        ]),
+        ...mapGetters({
+            currentPath: 'files/currentPath',
+        }),
     },
 }
 </script>

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -132,9 +132,9 @@ export default {
     },
     computed: {
         ...mapState({
-            'alerts': state => state.Site.alerts,
-            'errors': state => state.Site.errors,
-            'tmpSite': state => state.Site.current,
+            'alerts': state => state.sites.alerts,
+            'errors': state => state.sites.errors,
+            'tmpSite': state => state.sites.current,
         }),
     },
     watch: {
@@ -149,11 +149,11 @@ export default {
     },
     methods: {
         updateSite(id) {
-            this.$store.dispatch('updateSite', {id, data: this.tmpSite});
+            this.$store.dispatch('sites/update', {id, data: this.tmpSite});
         },
         deleteSite() {
             confirm("Deletion is permanent! Are you sure?") &&
-                this.$store.dispatch('deleteSite', this.site.id).then(
+                this.$store.dispatch('sites/delete', this.site.id).then(
                     response => this.$router.push({ name: 'apps' })
                 );
         },

--- a/resources/js/components/System/GroupEditor.vue
+++ b/resources/js/components/System/GroupEditor.vue
@@ -68,15 +68,15 @@ import { mapState, mapGetters } from 'vuex';
 export default {
     computed: {
         ...mapState({
-            editing: state => state.Group.editing,
-            editMode: state => state.Group.editMode,
-            oldGroup: state => state.Group.clean,
-            tmpGroup: state => state.Group.group,
+            editing: state => state.systemGroups.editing,
+            editMode: state => state.systemGroups.editMode,
+            oldGroup: state => state.systemGroups.clean,
+            tmpGroup: state => state.systemGroups.group,
         }),
-        ...mapGetters([
-            'users',
-            'userDropdown',
-        ]),
+        ...mapGetters({
+            users: 'systemUsers/all',
+            userDropdown: 'systemUsers/dropdown',
+        }),
     },
     data () {
         return {
@@ -95,7 +95,7 @@ export default {
                 return;
             }
 
-            this.$store.dispatch('createGroup', this.tmpGroup);
+            this.$store.dispatch('systemGroups/create', this.tmpGroup);
         },
         updateGroup (gid) {
             if (this.deleted.length) {
@@ -106,10 +106,10 @@ export default {
                 });
             }
 
-            this.$store.dispatch('updateGroup', {gid, data: this.tmpGroup});
+            this.$store.dispatch('systemGroups/update', {gid, data: this.tmpGroup});
         },
         deleteGroup (gid) {
-            this.$store.dispatch('deleteGroup', gid);
+            this.$store.dispatch('systemGroups/delete', gid);
         },
         addUser () {
             let user = this.users[this.users.findIndex(
@@ -135,7 +135,7 @@ export default {
         },
         reset () {
             this.deleted = [];
-            this.$store.commit('unsetEditorGroup');
+            this.$store.commit('systemGroups/unsetEditorGroup');
         },
     },
 };

--- a/resources/js/components/System/Groups.vue
+++ b/resources/js/components/System/Groups.vue
@@ -53,30 +53,30 @@ export default {
         SystemGroupEditor,
     },
     mounted () {
-        this.$store.dispatch('loadGroups');
-        this.$store.dispatch('loadUsers');
+        this.$store.dispatch('systemGroups/load');
+        this.$store.dispatch('systemUsers/load');
     },
     computed: {
         ...mapState({
-            editing: state => state.Group.editing,
-            search: state => state.Group.currentFilter,
-            showSysGroups: state => state.Group.showSystem,
+            editing: state => state.systemGroups.editing,
+            search: state => state.systemGroups.currentFilter,
+            showSysGroups: state => state.systemGroups.showSystem,
         }),
-        ...mapGetters([
-            'groups',
-            'filteredGroups',
-        ]),
+        ...mapGetters({
+            groups: 'systemGroups/all',
+            filteredGroups: 'systemGroups/filtered',
+        }),
         listWidth() {
             return this.editing ? 10 : 16;
         },
     },
     methods: {
         ...mapMutations({
-            filterGroups: 'setFilter',
-            toggleSysGroups: 'toggleSystemGroups',
+            filterGroups: 'systemGroups/setFilter',
+            toggleSysGroups: 'systemGroups/toggleSystemGroups',
         }),
         ...mapActions({
-            edit: 'editGroup',
+            edit: 'systemGroups/edit',
         }),
     },
 }

--- a/resources/js/components/System/UserEditor.vue
+++ b/resources/js/components/System/UserEditor.vue
@@ -73,15 +73,15 @@ import { mapState, mapGetters } from 'vuex';
 export default {
     computed: {
         ...mapState({
-            editing: state => state.User.editing,
-            editMode: state => state.User.editMode,
-            oldUser: state => state.User.clean,
-            tmpUser: state => state.User.user,
+            editing: state => state.systemUsers.editing,
+            editMode: state => state.systemUsers.editMode,
+            oldUser: state => state.systemUsers.clean,
+            tmpUser: state => state.systemUsers.user,
         }),
-        ...mapGetters([
-            'groups',
-            'groupDropdown',
-        ]),
+        ...mapGetters({
+            groups: 'systemGroups/all',
+            groupDropdown: 'systemGroups/dropdown',
+        }),
     },
     data () {
         return {
@@ -100,7 +100,7 @@ export default {
                 return;
             }
 
-            this.$store.dispatch('createUser', this.tmpUser);
+            this.$store.dispatch('systemUsers/create', this.tmpUser);
         },
         updateUser (uid) {
             if (this.deleted.length) {
@@ -111,10 +111,10 @@ export default {
                 });
             }
 
-            this.$store.dispatch('updateUser', {uid, user: this.tmpUser});
+            this.$store.dispatch('systemUsers/update', {uid, user: this.tmpUser});
         },
         deleteUser (uid) {
-            this.$store.dispatch('deleteUser', uid);
+            this.$store.dispatch('systemUsers/delete', uid);
         },
         addGroup () {
             let group = this.groups[this.groups.findIndex(
@@ -140,7 +140,7 @@ export default {
         },
         reset () {
             this.deleted = [];
-            this.$store.commit('unsetEditorUser');
+            this.$store.commit('systemUsers/unsetEditorUser');
         },
     },
 };

--- a/resources/js/components/System/Users.vue
+++ b/resources/js/components/System/Users.vue
@@ -53,30 +53,30 @@ export default {
         SystemUserEditor,
     },
     mounted () {
-        this.$store.dispatch('loadUsers');
-        this.$store.dispatch('loadGroups');
+        this.$store.dispatch('systemUsers/load');
+        this.$store.dispatch('systemGroups/load');
     },
     computed: {
         ...mapState({
-            editing: state => state.User.editing,
-            search: state => state.User.currentFilter,
-            showSysUsers: state => state.User.showSystem,
+            editing: state => state.systemUsers.editing,
+            search: state => state.systemUsers.currentFilter,
+            showSysUsers: state => state.systemUsers.showSystem,
         }),
-        ...mapGetters([
-            'users',
-            'filteredUsers',
-        ]),
+        ...mapGetters({
+            users: 'systemUsers/all',
+            filteredUsers: 'systemUsers/filtered',
+        }),
         listWidth() {
             return this.editing ? 10 : 16;
         },
     },
     methods: {
         ...mapActions({
-            edit: 'editUser',
+            edit: 'systemUsers/edit',
         }),
         ...mapMutations({
-            filterUsers: 'setFilter',
-            toggleSysUsers: 'toggleSystemUsers',
+            filterUsers: 'systemUsers/setFilter',
+            toggleSysUsers: 'systemUsers/toggleSystemUsers',
         }),
     },
 };

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -40,10 +40,10 @@ import FileList from '../../components/Files/Browser/FileList';
 export default {
     mounted () {
         this.$store.dispatch('sites/load');
-        this.$store.dispatch('loadFiles', { path: this.path });
+        this.$store.dispatch('files/load', { path: this.path });
     },
     beforeRouteUpdate (to, from, next) {
-        this.$store.dispatch('loadFiles', { path: to.params.path });
+        this.$store.dispatch('files/load', { path: to.params.path });
         next();
     },
     props: [
@@ -54,9 +54,9 @@ export default {
     },
     computed: {
         ...mapGetters({
-            currentPath: 'currentPath',
+            currentPath: 'files/currentPath',
             findSite: 'sites/findByDocroot',
-            files: 'files',
+            files: 'files/all',
         }),
         pathParts: function() {
             let parts = [],
@@ -94,7 +94,7 @@ export default {
             next = next ? next : '/';
 
             this.$router.push({ name: 'files', params: { path: next } });
-            this.$store.dispatch('loadFiles', { path: next });
+            this.$store.dispatch('files/load', { path: next });
         },
     }
 }

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -39,7 +39,7 @@ import FileList from '../../components/Files/Browser/FileList';
 
 export default {
     mounted () {
-        this.$store.dispatch('loadSites');
+        this.$store.dispatch('sites/load');
         this.$store.dispatch('loadFiles', { path: this.path });
     },
     beforeRouteUpdate (to, from, next) {
@@ -53,11 +53,11 @@ export default {
         FileList,
     },
     computed: {
-        ...mapGetters([
-            'currentPath',
-            'getSiteByDocroot',
-            'files',
-        ]),
+        ...mapGetters({
+            currentPath: 'currentPath',
+            findSite: 'sites/findByDocroot',
+            files: 'files',
+        }),
         pathParts: function() {
             let parts = [],
                 path = '';
@@ -74,7 +74,7 @@ export default {
             return parts;
         },
         site: function() {
-            return this.getSiteByDocroot(this.currentPath);
+            return this.findSite(this.currentPath);
         },
     },
     methods: {

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -27,15 +27,15 @@ import { mapGetters } from 'vuex';
 
 export default {
     mounted () {
-        this.$store.dispatch('openFile', { file: this.filePath });
+        this.$store.dispatch('files/open', { file: this.filePath });
     },
     props: [
         'filePath',
     ],
     computed: {
-        ...mapGetters([
-            'file',
-        ]),
+        ...mapGetters({
+            file: 'files/file',
+        }),
     },
     methods: {
         backToDir: function () {

--- a/resources/js/pages/Sites.vue
+++ b/resources/js/pages/Sites.vue
@@ -7,7 +7,7 @@
                         v-model="site.name" @input="filterSites" @keyup.enter="createOrEdit"></sui-input>
             </sui-grid-column>
         </sui-grid-row>
-        <router-view id="sites" :sites="filteredSites" />
+        <router-view id="sites" :sites="sites" />
     </sui-grid>
 </template>
 
@@ -17,15 +17,14 @@ import store from '../store';
 
 export default {
     beforeRouteEnter (to, from, next) {
-        store.dispatch('Site/loadSites').then(() => next());
+        store.dispatch('sites/load').then(() => next());
     },
     computed: {
         ...mapState({
-            site: state => state.Site.site,
+            site: state => state.sites.site,
         }),
         ...mapGetters({
-            sites: 'Site/sites',
-            filteredSites: 'Site/filteredSites',
+            sites: 'sites/filtered',
         }),
         filterIcon: function () {
             const match = this.site.name.toLowerCase();
@@ -34,7 +33,7 @@ export default {
                 return 'search';
             }
 
-            if ('object' == typeof(this.filteredSites.find(s => s.name.toLowerCase() == match))) {
+            if ('object' == typeof(this.sites.find(s => s.name.toLowerCase() == match))) {
                 return 'cogs';
             }
 
@@ -43,7 +42,7 @@ export default {
     },
     methods: {
         ...mapMutations({
-            filterSites: 'Site/setFilter',
+            filterSites: 'sites/setFilter',
         }),
         createOrEdit: function () {
             const match = this.site.name.toLowerCase();
@@ -52,13 +51,13 @@ export default {
                 return;
             }
 
-            let result = this.filteredSites.find(s => s.name.toLowerCase() == match);
+            let result = this.sites.find(s => s.name.toLowerCase() == match);
 
             if (typeof(result) === 'object') {
                 return this.$router.push({ name: 'apps.edit', params: { id: result.id }});
             }
 
-            this.$store.dispatch('createSite');
+            this.$store.dispatch('sites/create');
         },
     }
 }

--- a/resources/js/pages/Sites.vue
+++ b/resources/js/pages/Sites.vue
@@ -17,16 +17,16 @@ import store from '../store';
 
 export default {
     beforeRouteEnter (to, from, next) {
-        store.dispatch('loadSites').then(() => next());
+        store.dispatch('Site/loadSites').then(() => next());
     },
     computed: {
         ...mapState({
             site: state => state.Site.site,
         }),
-        ...mapGetters([
-            'sites',
-            'filteredSites',
-        ]),
+        ...mapGetters({
+            sites: 'Site/sites',
+            filteredSites: 'Site/filteredSites',
+        }),
         filterIcon: function () {
             const match = this.site.name.toLowerCase();
 
@@ -43,7 +43,7 @@ export default {
     },
     methods: {
         ...mapMutations({
-            filterSites: 'setFilter',
+            filterSites: 'Site/setFilter',
         }),
         createOrEdit: function () {
             const match = this.site.name.toLowerCase();

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -85,7 +85,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapGetters } from 'vuex';
 import SiteItem from '../../components/Sites/SiteItem';
 
 export default {
@@ -100,8 +100,11 @@ export default {
         sites: Array,
     },
     computed: {
+        ...mapGetters({
+            findSite: 'sites/findById',
+        }),
         site(){
-            return this.sites.find(s => s.id === this.id);
+            return this.findSite(this.id);
         },
     },
     methods: {

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -106,7 +106,7 @@ export default {
     },
     methods: {
         ...mapActions({
-            pullFiles: 'pullSiteFiles',
+            pullFiles: 'sites/pull',
         }),
     },
 }

--- a/resources/js/pages/Sites/Edit.vue
+++ b/resources/js/pages/Sites/Edit.vue
@@ -42,7 +42,7 @@ export default {
     },
     methods: {
         edit(id) {
-            return store.dispatch('editSite', parseInt(id));
+            return store.dispatch('sites/edit', parseInt(id));
         },
     },
 }

--- a/resources/js/pages/Sites/Edit.vue
+++ b/resources/js/pages/Sites/Edit.vue
@@ -12,6 +12,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import SiteEditor from '../../components/Sites/Editor';
 import SiteItem from '../../components/Sites/SiteItem';
 import store from '../../store';
@@ -36,8 +37,11 @@ export default {
         next();
     },
     computed: {
+        ...mapGetters({
+            findSite: 'sites/findById',
+        }),
         site(){
-            return this.sites.find(s => s.id === this.id);
+            return this.findSite(this.id);
         },
     },
     methods: {

--- a/resources/js/pages/Sites/List.vue
+++ b/resources/js/pages/Sites/List.vue
@@ -23,8 +23,8 @@ export default {
     ],
     computed: {
         ...mapState({
-            alerts: state => state.Site.alerts,
-            errors: state => state.Site.errors,
+            alerts: state => state.sites.alerts,
+            errors: state => state.sites.errors,
         }),
     },
 }

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -13,7 +13,7 @@ export default new VueX.Store ({
         Auth,
         sites: Site,
         Files,
-        Group,
-        User,
+        systemGroups: Group,
+        systemUsers: User,
     }
 });

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import VueX from 'vuex';
 import Auth from './modules/Auth';
 import Site from './modules/Site';
-import Files from './modules/FileManager';
+import FileManager from './modules/FileManager';
 import Group from './modules/System/Group';
 import User from './modules/System/User';
 
@@ -12,7 +12,7 @@ export default new VueX.Store ({
     modules: {
         Auth,
         sites: Site,
-        Files,
+        files: FileManager,
         systemGroups: Group,
         systemUsers: User,
     }

--- a/resources/js/store/index.js
+++ b/resources/js/store/index.js
@@ -11,7 +11,7 @@ Vue.use(VueX);
 export default new VueX.Store ({
     modules: {
         Auth,
-        Site,
+        sites: Site,
         Files,
         Group,
         User,

--- a/resources/js/store/modules/FileManager.js
+++ b/resources/js/store/modules/FileManager.js
@@ -1,4 +1,5 @@
 export default {
+    namespaced: true,
     state: {
         currentPath: '',
         files: [],
@@ -16,7 +17,7 @@ export default {
         }
     },
     actions: {
-        loadFiles: ({commit}, {path}) => {
+        load: ({commit}, {path}) => {
             return new Promise((resolve, reject) =>
                 axios.get('/api/files', {
                     params: { path: path },
@@ -27,7 +28,7 @@ export default {
                 }).catch(error => reject(error))
             );
         },
-        openFile: ({commit}, {file}) => {
+        open: ({commit}, {file}) => {
             return new Promise((resolve, reject) =>
                 axios.get('/api/files/', {
                     params: { file: file }
@@ -51,7 +52,7 @@ export default {
         },
     },
     getters: {
-        files: state => state.files,
+        all: state => state.files,
         file: state => state.file,
         currentPath: state => state.currentPath,
     },

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -66,7 +66,7 @@ export default {
         },
     },
     actions: {
-        loadSites: ({commit}) => {
+        load: ({commit}) => {
             return new Promise((resolve, reject) =>
                 axios.get('/api/sites') .then(response => {
                     commit('setSites', response.data);
@@ -74,17 +74,17 @@ export default {
                 }).catch(error => reject(error))
             );
         },
-        editSite: ({commit}, site) => {
+        edit: ({commit}, site) => {
             commit('setEditorSite', site);
         },
-        createSite: ({commit, state}) => {
+        create: ({commit, state}) => {
             axios.post('/api/sites', state.site).then(response => {
                 commit('addSite', response.data);
                 commit('clearMessages');
                 commit('setSuccess', "The site '" + response.data.name + "' has been created.");
             });
         },
-        updateSite: ({commit}, site) => {
+        update: ({commit}, site) => {
             axios.put('/api/sites/'+site.id, site.data).then(response => {
                 commit('clearMessages');
                 commit('updateSite', {
@@ -108,10 +108,10 @@ export default {
                 }
             });
         },
-        pullSiteFiles: ({commit, state}, site) => {
+        pull: ({commit, state}, site) => {
             return axios.post('/api/sites/'+site.id+'/pull');
         },
-        deleteSite: ({commit, state}, id) => {
+        delete: ({commit, state}, id) => {
             return new Promise((resolve, reject) => {
                 axios.delete('/api/sites/' + id).then(response => {
                     commit('removeSite', id);
@@ -127,16 +127,16 @@ export default {
         },
     },
     getters: {
-        filteredSites: state => {
+        all: state => {
+            return state.sites;
+        },
+        filtered: state => {
             return state.sites.filter(site => {
                 return site.name.toLowerCase().includes(state.currentFilter.toLowerCase());
             });
         },
-        getSiteByDocroot: (state) => (path) => {
+        findByDocroot: (state) => (path) => {
             return state.sites.find(s => s.document_root == path);
-        },
-        sites: state => {
-            return state.sites;
         },
     },
 }

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -1,4 +1,5 @@
 export default {
+    namespaced: true,
     state: {
         alerts: [],
         current: {},

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -135,6 +135,9 @@ export default {
                 return site.name.toLowerCase().includes(state.currentFilter.toLowerCase());
             });
         },
+        findById: (state) => (id) => {
+            return state.sites.find(s => s.id === id);
+        },
         findByDocroot: (state) => (path) => {
             return state.sites.find(s => s.document_root == path);
         },

--- a/resources/js/store/modules/System/Group.js
+++ b/resources/js/store/modules/System/Group.js
@@ -1,4 +1,5 @@
 export default {
+    namespaced: true,
     state: {
         clean: null,
         currentFilter: '',
@@ -68,25 +69,25 @@ export default {
         },
     },
     actions: {
-        loadGroups: ({commit}) => {
+        load: ({commit}) => {
             axios.get('/api/system/groups').then(response => {
                 commit('setGroups', response.data);
             });
         },
-        editGroup: ({commit, state, getters}, group) => {
+        edit: ({commit, state, getters}, group) => {
             if (state.editing && getters.groupIsDirty) {
                 return;
             }
 
             commit('setEditorGroup', group);
         },
-        createGroup: ({commit, state}) => {
+        create: ({commit, state}) => {
             axios.post('/api/system/groups', state.group).then(response => {
                 commit('addGroup', response.data);
                 commit('unsetEditorGroup');
             });
         },
-        updateGroup: ({commit}, group) => {
+        update: ({commit}, group) => {
             axios.put('/api/system/groups/'+group.gid, group.data).then(response => {
                 commit('updateGroup', {
                     gid: group.gid,
@@ -95,7 +96,7 @@ export default {
                 commit('unsetEditorGroup');
             });
         },
-        deleteGroup: ({commit, state}, gid) => {
+        delete: ({commit, state}, gid) => {
             axios.delete('/api/system/groups/'+gid).then(response => {
                 commit('removeGroup', state.group.gid_original);
                 commit('unsetEditorGroup');
@@ -103,10 +104,19 @@ export default {
         },
     },
     getters: {
-        groups: state => {
+        all: state => {
             return state.groups;
         },
-        groupDropdown: state => {
+        filtered: state => {
+            return state.groups.filter(group => {
+                if (!state.showSystem && group.gid < 1000) {
+                    return false;
+                }
+
+                return group.name.includes(state.currentFilter);
+            });
+        },
+        dropdown: state => {
             return state.groups.map(group => {
                 return {
                     icon: 'users',
@@ -127,14 +137,5 @@ export default {
                 || old.gid != now.gid
                 || !_.isEqual(old.users, now.users);
         },
-        filteredGroups: state => {
-            return state.groups.filter(group => {
-                if (!state.showSystem && group.gid < 1000) {
-                    return false;
-                }
-
-                return group.name.includes(state.currentFilter);
-            });
-        }
     },
 };

--- a/resources/js/store/modules/System/User.js
+++ b/resources/js/store/modules/System/User.js
@@ -1,4 +1,5 @@
 export default {
+    namespaced: true,
     state: {
         clean: null,
         currentFilter: '',
@@ -72,12 +73,12 @@ export default {
         },
     },
     actions: {
-        loadUsers: ({commit}) => {
+        load: ({commit}) => {
             axios.get('/api/system/users').then(response => {
                 commit('setUsers', response.data);
             });
         },
-        editUser: ({commit, state, getters}, user) => {
+        edit: ({commit, state, getters}, user) => {
             // TODO: Add some kind of modal/confirm prompt in case
             //  the user wants to abort any changes and continue.
             if (state.editing && getters.userIsDirty) {
@@ -86,13 +87,13 @@ export default {
 
             commit('setEditorUser', user);
         },
-        createUser: ({commit, state}, user) => {
+        create: ({commit, state}, user) => {
             axios.post('/api/system/users', user).then(response => {
                 commit('addUser', response.data);
                 commit('unsetEditorUser');
             });
         },
-        updateUser: ({commit}, {uid, user}) => {
+        update: ({commit}, {uid, user}) => {
             axios.put('/api/system/users/'+uid, user).then(response => {
                 commit('updateUser', {
                     uid: uid,
@@ -101,7 +102,7 @@ export default {
                 commit('unsetEditorUser');
             });
         },
-        deleteUser: ({commit, state}, uid) => {
+        delete: ({commit, state}, uid) => {
             axios.delete('/api/system/users/'+uid).then(response => {
                 commit('removeUser', state.user.uid_original);
                 commit('unsetEditorUser');
@@ -109,10 +110,19 @@ export default {
         },
     },
     getters: {
-        users: state => {
+        all: state => {
             return state.users;
         },
-        userDropdown: state => {
+        filtered: state => {
+            return state.users.filter(user => {
+                if (!state.showSystem && user.uid < 1000) {
+                    return false;
+                }
+
+                return user.name.includes(state.currentFilter);
+            });
+        },
+        dropdown: state => {
             return state.users.map(user => {
                 return {
                     icon: 'user',
@@ -133,15 +143,6 @@ export default {
                 || old.uid != now.uid
                 || old.gid != now.gid
                 || !_.isEqual(old.groups, now.groups);
-        },
-        filteredUsers: state => {
-            return state.users.filter(user => {
-                if (!state.showSystem && user.uid < 1000) {
-                    return false;
-                }
-
-                return user.name.includes(state.currentFilter);
-            });
         },
     },
 };


### PR DESCRIPTION
Namespaces every VueX module with the exception of `Auth` because that's probably better off in the root namespace. At least now there's nothing left for it to conflict with...

Also taken the liberty of renaming some actions. Things like `createUser`, `updateSite` etc made sense before, but now we're prefixing with the module name it gets a bit dirty. `users/create` is far better than `users/createUser`.

Fixes #144.