### PR TITLE
Move version info to main app layout

### DIFF
--- a/resources/js/layouts/Servidor.vue
+++ b/resources/js/layouts/Servidor.vue
@@ -36,11 +36,10 @@
             <stats-bar id="stats-bar" />
 
             <router-view id="content" />
-
-            <div class="version">
-                <p>Servidor v{{ version }}</p>
-            </div>
         </section>
+        <footer>
+            <p>Servidor v{{ version }}</p>
+        </footer>
     </div>
 </template>
 

--- a/resources/js/layouts/Servidor.vue
+++ b/resources/js/layouts/Servidor.vue
@@ -36,6 +36,10 @@
             <stats-bar id="stats-bar" />
 
             <router-view id="content" />
+
+            <div class="version">
+                <p>Servidor v{{ version }}</p>
+            </div>
         </section>
     </div>
 </template>
@@ -44,6 +48,12 @@
 import { mapGetters, mapActions, mapState } from 'vuex';
 
 export default {
+    props: {
+        version: {
+            type: String,
+            default: "0.0.0",
+        },
+    },
     computed: {
         ...mapGetters([
             'loggedIn',

--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -10,6 +10,14 @@ body {
             #content {
                 margin-top: 1rem;
             }
+
+            .version {
+                position: absolute;
+                bottom: 0;
+                text-align: center;
+                height: 40px;
+                width: calc(100% - #{$sidebar-width});
+            }
         }
     }
 }

--- a/resources/sass/_layout.scss
+++ b/resources/sass/_layout.scss
@@ -10,14 +10,6 @@ body {
             #content {
                 margin-top: 1rem;
             }
-
-            .version {
-                position: absolute;
-                bottom: 0;
-                text-align: center;
-                height: 40px;
-                width: calc(100% - #{$sidebar-width});
-            }
         }
     }
 }

--- a/resources/sass/layout/_footer.scss
+++ b/resources/sass/layout/_footer.scss
@@ -4,8 +4,8 @@ html {
     height: unset;
 }
 
-body {
-    margin-bottom: 60px;
+#app {
+    padding-bottom: 60px;
 
     & > footer {
         margin-left: $sidebar_width;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,10 +12,6 @@
     <body>
         @yield('content')
 
-        <footer>
-            <p>Servidor v{{ SERVIDOR_VERSION }}</p>
-        </footer>
-
         <script src="{{ mix('js/app.js') }}"></script>
     </body>
 </html>

--- a/resources/views/servidor.blade.php
+++ b/resources/views/servidor.blade.php
@@ -1,5 +1,5 @@
 @extends ('layouts.app')
 
 @section ('content')
-<router-view id="app"></router-view>
+<router-view id="app" version="{{ SERVIDOR_VERSION }}"></router-view>
 @endsection


### PR DESCRIPTION
I moved the footer over to vue where it seems to make more sense.

Since the footer is now technically a part of the `<section class="main>` section, I swapped `<footer>` with `<div class="version">` which was added to _layouts.scss. This made the most since to me at the time since it allows to add an actual "global" footer later using _footer.scss (which i left behind) and the `<footer>` tag.

Let me know how you feel about the changes or if you'd like to see this done another way.

Fixes #149 