### PR TITLE
Update Mix, Sass Loader and Cross-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
             }
         },
         "@babel/core": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-            "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.2.tgz",
+            "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.5.5",
-                "@babel/helpers": "^7.5.5",
-                "@babel/parser": "^7.5.5",
-                "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.5.5",
-                "@babel/types": "^7.5.5",
+                "@babel/generator": "^7.6.2",
+                "@babel/helpers": "^7.6.2",
+                "@babel/parser": "^7.6.2",
+                "@babel/template": "^7.6.0",
+                "@babel/traverse": "^7.6.2",
+                "@babel/types": "^7.6.0",
                 "convert-source-map": "^1.1.0",
                 "debug": "^4.1.0",
                 "json5": "^2.1.0",
@@ -51,16 +51,15 @@
             }
         },
         "@babel/generator": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-            "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
+            "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.5.5",
+                "@babel/types": "^7.6.0",
                 "jsesc": "^2.5.1",
                 "lodash": "^4.17.13",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "source-map": "^0.5.0"
             }
         },
         "@babel/helper-annotate-as-pure": {
@@ -256,14 +255,14 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-            "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+            "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.5.5",
-                "@babel/types": "^7.5.5"
+                "@babel/template": "^7.6.0",
+                "@babel/traverse": "^7.6.2",
+                "@babel/types": "^7.6.0"
             }
         },
         "@babel/highlight": {
@@ -278,9 +277,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-            "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+            "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
@@ -315,9 +314,9 @@
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-            "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+            "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -335,14 +334,14 @@
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-            "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+            "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.5.4"
+                "regexpu-core": "^4.6.0"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -420,9 +419,9 @@
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-            "integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.2.tgz",
+            "integrity": "sha512-zZT8ivau9LOQQaOGC7bQLQOT4XPkPXgN2ERfUgk1X8ql+mVkLc4E8eKk+FO3o0154kxzqenWCorfmEXpEZcrSQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -455,23 +454,23 @@
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-            "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+            "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-            "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+            "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.5.4"
+                "regexpu-core": "^4.6.0"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -542,9 +541,9 @@
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-            "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+            "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-transforms": "^7.4.4",
@@ -575,12 +574,12 @@
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-            "integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.2.tgz",
+            "integrity": "sha512-xBdB+XOs+lgbZc2/4F5BVDVcDNS4tcSKQc96KmlqLEAwz6tpYPEvPdmDfvVG0Ssn8lAhronaRs6Z6KSexIpK5g==",
             "dev": true,
             "requires": {
-                "regexp-tree": "^0.1.6"
+                "regexpu-core": "^4.6.0"
             }
         },
         "@babel/plugin-transform-new-target": {
@@ -641,9 +640,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-            "integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+            "integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
@@ -662,9 +661,9 @@
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-            "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+            "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0"
@@ -700,20 +699,20 @@
             }
         },
         "@babel/plugin-transform-unicode-regex": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-            "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+            "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/helper-regex": "^7.4.4",
-                "regexpu-core": "^4.5.4"
+                "regexpu-core": "^4.6.0"
             }
         },
         "@babel/preset-env": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-            "integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.2.tgz",
+            "integrity": "sha512-Ru7+mfzy9M1/YTEtlDS8CD45jd22ngb9tXnn64DvQK3ooyqSw9K4K9DUWmYknTTVk4TqygL9dqCrZgm1HMea/Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
@@ -721,9 +720,9 @@
                 "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
                 "@babel/plugin-proposal-dynamic-import": "^7.5.0",
                 "@babel/plugin-proposal-json-strings": "^7.2.0",
-                "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+                "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
                 "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
                 "@babel/plugin-syntax-async-generators": "^7.2.0",
                 "@babel/plugin-syntax-dynamic-import": "^7.2.0",
                 "@babel/plugin-syntax-json-strings": "^7.2.0",
@@ -732,11 +731,11 @@
                 "@babel/plugin-transform-arrow-functions": "^7.2.0",
                 "@babel/plugin-transform-async-to-generator": "^7.5.0",
                 "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-                "@babel/plugin-transform-block-scoping": "^7.5.5",
+                "@babel/plugin-transform-block-scoping": "^7.6.2",
                 "@babel/plugin-transform-classes": "^7.5.5",
                 "@babel/plugin-transform-computed-properties": "^7.2.0",
-                "@babel/plugin-transform-destructuring": "^7.5.0",
-                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/plugin-transform-destructuring": "^7.6.0",
+                "@babel/plugin-transform-dotall-regex": "^7.6.2",
                 "@babel/plugin-transform-duplicate-keys": "^7.5.0",
                 "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
                 "@babel/plugin-transform-for-of": "^7.4.4",
@@ -744,10 +743,10 @@
                 "@babel/plugin-transform-literals": "^7.2.0",
                 "@babel/plugin-transform-member-expression-literals": "^7.2.0",
                 "@babel/plugin-transform-modules-amd": "^7.5.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.6.0",
                 "@babel/plugin-transform-modules-systemjs": "^7.5.0",
                 "@babel/plugin-transform-modules-umd": "^7.2.0",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.2",
                 "@babel/plugin-transform-new-target": "^7.4.4",
                 "@babel/plugin-transform-object-super": "^7.5.5",
                 "@babel/plugin-transform-parameters": "^7.4.4",
@@ -755,12 +754,12 @@
                 "@babel/plugin-transform-regenerator": "^7.4.5",
                 "@babel/plugin-transform-reserved-words": "^7.2.0",
                 "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-                "@babel/plugin-transform-spread": "^7.2.0",
+                "@babel/plugin-transform-spread": "^7.6.2",
                 "@babel/plugin-transform-sticky-regex": "^7.2.0",
                 "@babel/plugin-transform-template-literals": "^7.4.4",
                 "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-                "@babel/plugin-transform-unicode-regex": "^7.4.4",
-                "@babel/types": "^7.5.5",
+                "@babel/plugin-transform-unicode-regex": "^7.6.2",
+                "@babel/types": "^7.6.0",
                 "browserslist": "^4.6.0",
                 "core-js-compat": "^3.1.1",
                 "invariant": "^2.2.2",
@@ -769,9 +768,9 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-            "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+            "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
             "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.2"
@@ -786,28 +785,28 @@
             }
         },
         "@babel/template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+            "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/parser": "^7.6.0",
+                "@babel/types": "^7.6.0"
             }
         },
         "@babel/traverse": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-            "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
+            "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.5.5",
+                "@babel/generator": "^7.6.2",
                 "@babel/helper-function-name": "^7.1.0",
                 "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/parser": "^7.5.5",
-                "@babel/types": "^7.5.5",
+                "@babel/parser": "^7.6.2",
+                "@babel/types": "^7.6.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.13"
@@ -831,9 +830,9 @@
             }
         },
         "@babel/types": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-            "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+            "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
@@ -881,9 +880,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.7.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-            "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+            "version": "12.7.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
+            "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==",
             "dev": true
         },
         "@types/q": {
@@ -1633,9 +1632,9 @@
             "dev": true
         },
         "bluebird": {
-            "version": "3.5.5",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
+            "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
             "dev": true
         },
         "bn.js": {
@@ -1972,9 +1971,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30000989",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-            "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+            "version": "1.0.30000998",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000998.tgz",
+            "integrity": "sha512-8Tj5sPZR9kMHeDD9SZXIVr5m9ofufLLCG2Y4QwQrH18GIwG+kCc+zYdlR036ZRkuKjVVetyxeAgGA1xF7XdmzQ==",
             "dev": true
         },
         "chalk": {
@@ -2089,9 +2088,9 @@
             }
         },
         "chownr": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-            "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
             "dev": true
         },
         "chrome-trace-event": {
@@ -3174,9 +3173,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.252",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.252.tgz",
-            "integrity": "sha512-NWJ5TztDnjExFISZHFwpoJjMbLUifsNBnx7u2JI0gCw6SbKyQYYWWtBHasO/jPtHym69F4EZuTpRNGN11MT/jg==",
+            "version": "1.3.273",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.273.tgz",
+            "integrity": "sha512-0kUppiHQvHEENHh+nTtvTt4eXMwcPyWmMaj73GPrSEm3ldKhmmHuOH6IjrmuW6YmyS/fpXcLvMQLNVpqRhpNWw==",
             "dev": true
         },
         "elliptic": {
@@ -3213,9 +3212,9 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
                 "once": "^1.4.0"
@@ -3257,18 +3256,18 @@
             }
         },
         "error-stack-parser": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.3.tgz",
-            "integrity": "sha512-vRC4rKv87twMZy92X4+TmUdv3iYMsmePbpG/YguHsfzmZ8bYJZYYep7yrXH09yFUaCEPKgNK5X79+Yq7hwLVOA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.4.tgz",
+            "integrity": "sha512-fZ0KkoxSjLFmhW5lHbUT3tLwy3nX1qEzMYo8koY1vrsAco53CMT1djnBSeC/wUjTEZRhZl9iRw7PaMaxfJ4wzQ==",
             "dev": true,
             "requires": {
-                "stackframe": "^1.0.4"
+                "stackframe": "^1.1.0"
             }
         },
         "es-abstract": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.1.tgz",
-            "integrity": "sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+            "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.0",
@@ -3279,8 +3278,8 @@
                 "is-regex": "^1.0.4",
                 "object-inspect": "^1.6.0",
                 "object-keys": "^1.1.1",
-                "string.prototype.trimleft": "^2.0.0",
-                "string.prototype.trimright": "^2.0.0"
+                "string.prototype.trimleft": "^2.1.0",
+                "string.prototype.trimright": "^2.1.0"
             }
         },
         "es-to-primitive": {
@@ -3392,9 +3391,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+            "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
             "dev": true
         },
         "events": {
@@ -4314,12 +4313,12 @@
             "dev": true
         },
         "http-proxy": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
             "dev": true,
             "requires": {
-                "eventemitter3": "^3.0.0",
+                "eventemitter3": "^4.0.0",
                 "follow-redirects": "^1.0.0",
                 "requires-port": "^1.0.0"
             }
@@ -4909,9 +4908,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+            "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
             "dev": true,
             "requires": {
                 "minimist": "^1.2.0"
@@ -4939,9 +4938,9 @@
             "dev": true
         },
         "laravel-mix": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-4.1.4.tgz",
-            "integrity": "sha512-fpFNpPyYAdeZ5mozlKbHpw+tCiRFUCCdSsK/D2+yYhlyIEbzPcAe4ar5cjeT33TnDNiKXSS42cB58yUSW5Y5tg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-5.0.0.tgz",
+            "integrity": "sha512-QpsVoM6zGa83E5AUMwOmi4wKdYfJMaW1jIpJ1CCL74abOHj1ne25njBQ4detO41GAjIkZIkrmwECEcOebC8+3Q==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.2.0",
@@ -4976,7 +4975,7 @@
                 "terser": "^3.11.0",
                 "terser-webpack-plugin": "^1.2.2",
                 "vue-loader": "^15.4.2",
-                "webpack": "^4.27.1",
+                "webpack": "^4.36.1",
                 "webpack-cli": "^3.1.2",
                 "webpack-dev-server": "^3.1.14",
                 "webpack-merge": "^4.1.0",
@@ -5785,9 +5784,9 @@
             }
         },
         "merge2": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
-            "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+            "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
             "dev": true
         },
         "methods": {
@@ -6022,9 +6021,9 @@
             }
         },
         "node-forge": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.2.tgz",
-            "integrity": "sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
             "dev": true
         },
         "node-libs-browser": {
@@ -6080,9 +6079,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-            "integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
+            "version": "1.1.33",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.33.tgz",
+            "integrity": "sha512-I0V30bWQEoHb+10W8oedVoUrdjW5wIkYm0w7vvcrPO95pZY738m1k77GF5sO0vKg5eXYg9oGtrMAETbgZGm11A==",
             "dev": true,
             "requires": {
                 "semver": "^5.3.0"
@@ -6417,9 +6416,9 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-            "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
             "dev": true,
             "requires": {
                 "asn1.js": "^4.0.0",
@@ -7550,12 +7549,6 @@
             "integrity": "sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==",
             "dev": true
         },
-        "regexp-tree": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
-            "integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
-            "dev": true
-        },
         "regexp.prototype.flags": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -7566,9 +7559,9 @@
             }
         },
         "regexpu-core": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
-            "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+            "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.0",
@@ -7862,18 +7855,28 @@
             }
         },
         "sass-loader": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.3.1.tgz",
-            "integrity": "sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.0.tgz",
+            "integrity": "sha512-+qeMu563PN7rPdit2+n5uuYVR0SSVwm0JsOUsaJXzgYcClWSlmX0iHDnmeOobPkf5kUglVot3QS6SyLyaQoJ4w==",
             "dev": true,
             "requires": {
                 "clone-deep": "^4.0.1",
-                "loader-utils": "^1.0.1",
-                "neo-async": "^2.5.0",
-                "pify": "^4.0.1",
+                "loader-utils": "^1.2.3",
+                "neo-async": "^2.6.1",
+                "schema-utils": "^2.1.0",
                 "semver": "^6.3.0"
             },
             "dependencies": {
+                "schema-utils": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
+                    "integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.10.2",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7905,12 +7908,12 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.6",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.6.tgz",
-            "integrity": "sha512-i3+CeqxL7DpAazgVpAGdKMwHuL63B5nhJMh9NQ7xmChGkA3jNFflq6Jyo1LLJYcr3idWiNOPWHCrm4zMayLG4w==",
+            "version": "1.10.7",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+            "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
             "dev": true,
             "requires": {
-                "node-forge": "0.8.2"
+                "node-forge": "0.9.0"
             }
         },
         "semantic-ui-sass": {
@@ -8292,9 +8295,9 @@
             }
         },
         "sockjs-client": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
-            "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+            "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
             "dev": true,
             "requires": {
                 "debug": "^3.2.5",
@@ -8483,9 +8486,9 @@
             "dev": true
         },
         "stackframe": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-            "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.0.tgz",
+            "integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg==",
             "dev": true
         },
         "static-extend": {
@@ -8582,23 +8585,23 @@
             }
         },
         "string.prototype.trimleft": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-            "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+            "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.0.2"
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
             }
         },
         "string.prototype.trimright": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-            "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+            "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.0.2"
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
             }
         },
         "string_decoder": {
@@ -8720,9 +8723,9 @@
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.20.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+                    "version": "2.20.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+                    "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
                     "dev": true
                 },
                 "source-map": {
@@ -8751,9 +8754,9 @@
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.20.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+                    "version": "2.20.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+                    "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
                     "dev": true
                 },
                 "schema-utils": {
@@ -8774,9 +8777,9 @@
                     "dev": true
                 },
                 "terser": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/terser/-/terser-4.2.1.tgz",
-                    "integrity": "sha512-cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.4.tgz",
+                    "integrity": "sha512-Kcrn3RiW8NtHBP0ssOAzwa2MsIRQ8lJWiBG/K7JgqPlomA3mtb2DEmp4/hrUA+Jujx+WZ02zqd7GYD+QRBB/2Q==",
                     "dev": true,
                     "requires": {
                         "commander": "^2.20.0",
@@ -8881,12 +8884,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-            "dev": true
-        },
-        "trim-right": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "tslib": {
@@ -9212,9 +9209,9 @@
             "dev": true
         },
         "vue-hot-reload-api": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",
-            "integrity": "sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
+            "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
             "dev": true
         },
         "vue-loader": {
@@ -9857,9 +9854,9 @@
             }
         },
         "webpack": {
-            "version": "4.39.3",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz",
-            "integrity": "sha512-BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==",
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.0.tgz",
+            "integrity": "sha512-yNV98U4r7wX1VJAj5kyMsu36T8RPPQntcb5fJLOsMz/pt/WrKC0Vp1bAlqPLkA1LegSwQwf6P+kAbyhRKVQ72g==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.8.5",
@@ -9901,9 +9898,9 @@
             }
         },
         "webpack-cli": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.8.tgz",
-            "integrity": "sha512-RANYSXwikSWINjHMd/mtesblNSpjpDLoYTBtP99n1RhXqVI/wxN40Auqy42I7y4xrbmRBoA5Zy5E0JSBD5XRhw==",
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz",
+            "integrity": "sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==",
             "dev": true,
             "requires": {
                 "chalk": "2.4.2",
@@ -9976,9 +9973,9 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.1.tgz",
-            "integrity": "sha512-5MWu9SH1z3hY7oHOV6Kbkz5x7hXbxK56mGHNqHTe6d+ewxOwKUxoUJBs7QIaJb33lPjl9bJZ3X0vCoooUzC36A==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+            "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
             "dev": true,
             "requires": {
                 "memory-fs": "^0.4.1",
@@ -9997,41 +9994,41 @@
             }
         },
         "webpack-dev-server": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
-            "integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.2.tgz",
+            "integrity": "sha512-0xxogS7n5jHDQWy0WST0q6Ykp7UGj4YvWh+HVN71JoE7BwPxMZrwgraBvmdEMbDVMBzF0u+mEzn8TQzBm5NYJQ==",
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
                 "bonjour": "^3.5.0",
-                "chokidar": "^2.1.6",
+                "chokidar": "^2.1.8",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^1.6.0",
                 "debug": "^4.1.1",
                 "del": "^4.1.1",
                 "express": "^4.17.1",
                 "html-entities": "^1.2.1",
-                "http-proxy-middleware": "^0.19.1",
+                "http-proxy-middleware": "0.19.1",
                 "import-local": "^2.0.0",
                 "internal-ip": "^4.3.0",
                 "ip": "^1.1.5",
-                "is-absolute-url": "^3.0.0",
+                "is-absolute-url": "^3.0.3",
                 "killable": "^1.0.1",
-                "loglevel": "^1.6.3",
+                "loglevel": "^1.6.4",
                 "opn": "^5.5.0",
                 "p-retry": "^3.0.1",
-                "portfinder": "^1.0.21",
+                "portfinder": "^1.0.24",
                 "schema-utils": "^1.0.0",
-                "selfsigned": "^1.10.4",
+                "selfsigned": "^1.10.7",
                 "semver": "^6.3.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "0.3.19",
-                "sockjs-client": "1.3.0",
+                "sockjs-client": "1.4.0",
                 "spdy": "^4.0.1",
                 "strip-ansi": "^3.0.1",
                 "supports-color": "^6.1.0",
                 "url": "^0.11.0",
-                "webpack-dev-middleware": "^3.7.0",
+                "webpack-dev-middleware": "^3.7.2",
                 "webpack-log": "^2.0.0",
                 "ws": "^6.2.1",
                 "yargs": "12.0.5"
@@ -10615,9 +10612,9 @@
                     }
                 },
                 "is-absolute-url": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz",
-                    "integrity": "sha512-c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==",
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+                    "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
                     "dev": true
                 },
                 "ms": {
@@ -10810,9 +10807,9 @@
             "dev": true
         },
         "yallist": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2524,12 +2524,31 @@
             }
         },
         "cross-env": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
-            "integrity": "sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^6.0.5"
+                "cross-spawn": "^7.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.0.tgz",
+                    "integrity": "sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+                    "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+                    "dev": true
+                }
             }
         },
         "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "devDependencies": {
         "axios": "^0.19.0",
         "cross-env": "^5.2",
-        "laravel-mix": "^4.1.4",
+        "laravel-mix": "^5.0.0",
         "lodash": "^4.17.15",
         "popper.js": "^1.15",
         "resolve-url-loader": "3.1.0",
         "sass": "^1.23.0",
-        "sass-loader": "^7.1",
+        "sass-loader": "^8.0",
         "semantic-ui-sass": "^2.4.2",
         "vue": "^2.6.10",
         "vue-template-compiler": "^2.6.10"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "devDependencies": {
         "axios": "^0.19.0",
-        "cross-env": "^5.2",
+        "cross-env": "^6.0.3",
         "laravel-mix": "^5.0.0",
         "lodash": "^4.17.15",
         "popper.js": "^1.15",


### PR DESCRIPTION
All major versions, so these won't be handled be @depfu.

The laravel-mix update is to support sass-loader which, like cross-env, removes support for old Node versions.