### PR TITLE
Fix Old file flickers before showing the current file #118 

### DIFF
--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -6,7 +6,7 @@
                 <span class="pathbar">{{ filePath }}</span>
             </h2>
 
-            <sui-segment v-if="file.error == undefined">
+            <sui-segment v-if="file.error == undefined" :loading="loading">
                 <pre>{{ file.contents }}</pre>
             </sui-segment>
 
@@ -26,12 +26,19 @@
 import { mapGetters } from 'vuex';
 
 export default {
-    mounted () {
-        this.$store.dispatch('files/open', { file: this.filePath });
+    async mounted () {
+        this.loading = true;
+        await this.$store.dispatch('files/open', { file: this.filePath })
+            .finally(() => this.loading = false );
     },
     props: [
         'filePath',
     ],
+    data: () => {
+        return {
+            loading: false,
+        };
+    },
     computed: {
         ...mapGetters({
             file: 'files/file',

--- a/resources/js/store/modules/FileManager.js
+++ b/resources/js/store/modules/FileManager.js
@@ -12,6 +12,9 @@ export default {
         setFile: (state, file) => {
             state.file = file;
         },
+        clearFile: (state) => {
+            state.file = [];
+        },
         setPath: (state, path) => {
             state.currentPath = path;
         }
@@ -29,7 +32,8 @@ export default {
             );
         },
         open: ({commit}, {file}) => {
-            return new Promise((resolve, reject) =>
+            return new Promise((resolve, reject) => {
+                commit('clearFile');
                 axios.get('/api/files/', {
                     params: { file: file }
                 }).then(response => {
@@ -47,8 +51,8 @@ export default {
 
                     commit('setFile', data);
                     reject(error);
-                })
-            );
+                });
+            });
         },
     },
     getters: {


### PR DESCRIPTION
Before loading a new file the old file contents are now cleared.
Additionally I added loading state to the file viewer.

Fixes #118 