### PR TITLE
Refresh system info in the stats bar periodically

### DIFF
--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -52,25 +52,51 @@ export default {
     data () {
         return {
             loaded: false,
-            hostname: '',
+            cpu_usage: 0,
+            disk: {},
             distro: '',
+            hostname: '',
+            load_avg: {},
+            ram: {},
             version: '',
         };
     },
     mounted () {
         this.initStatsBar();
+
+        const refreshStatsBar = () => {
+            return setInterval(
+                () => this.initStatsBar(),
+                1000 * 60
+            );
+        };
+
+        const startStopRefreshStatsBar = () => {
+            if(document.hidden) {
+                clearInterval(refreshStatsBarIntervalId);
+            } else {
+                refreshStatsBarIntervalId = refreshStatsBar();
+            }
+        };
+
+        let refreshStatsBarIntervalId = refreshStatsBar();
+        document.addEventListener("visibilitychange", startStopRefreshStatsBar, false);
+
+        this.$once("hook:beforeDestroy", () => {
+            document.removeEventListener("visibilitychange", startStopRefreshStatsBar);
+        });
     },
     methods: {
         initStatsBar () {
             axios.get('/api/system-info').then(response => {
                 let data = response.data;
 
-                this.hostname = data.hostname;
                 this.cpu_usage = data.cpu;
-                this.load_avg = data.load_average;
-                this.ram = data.ram;
                 this.disk = data.disk;
                 this.distro = data.os.distro;
+                this.hostname = data.hostname;
+                this.load_avg = data.load_average;
+                this.ram = data.ram;
                 this.version = data.os.version;
 
                 this.loaded = true;


### PR DESCRIPTION
This will update the stats bar with new system info every 60 seconds.
Additionally the interval will be paused/resumed if the tab visibility changes.

Fixes #116