### PR TITLE
Fix 'undefined' showing in document root

### DIFF
--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -162,7 +162,7 @@ export default {
             let val = '';
 
             if (['basic', 'php', 'laravel'].includes(site.type)) {
-                val = '/var/www/' + site.primary_domain;
+                val = '/var/www/' + (site.primary_domain || '');
 
                 if (site.type == 'laravel') {
                     val += '/public';


### PR DESCRIPTION
Solves bug where undefined would be showing in document root when primary domain isn't set.

Fixes #171