### PR TITLE
Sites: Branch dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Highlight for current item in the list when editing a system user/group
 * Brand-spanking new file viewer using CodeMirror for themes etc
 * Databases can finally be listed on the Databases page
+* Current branches for a Site's repo are now listed in a dropdown
 
 ### Changed
 * Stats bar updated to refresh every 60s while the tab is visible

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -35,6 +35,22 @@ class SiteController extends Controller
     }
 
     /**
+     * Display a list of branches on the given site's repository.
+     *
+     * @param Site $site
+     *
+     * @return Response
+     */
+    public function branches(Site $site)
+    {
+        $cmd = "git ls-remote --heads '%s' | sed 's^.*refs/heads/^^'";
+
+        exec(sprintf($cmd, $site->source_repo), $branches);
+
+        return $branches;
+    }
+
+    /**
      * Pull the latest commit from Git.
      *
      * @param \Servidor\Site $site

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -37,15 +37,17 @@ class SiteController extends Controller
     /**
      * Display a list of branches on the given site's repository.
      *
-     * @param Site $site
+     * @param Request $request
+     * @param Site    $site
      *
      * @return Response
      */
-    public function branches(Site $site)
+    public function branches(Request $request, Site $site)
     {
         $cmd = "git ls-remote --heads '%s' | sed 's^.*refs/heads/^^'";
+        $repo = $request->query('repo', $site->source_repo);
 
-        exec(sprintf($cmd, $site->source_repo), $branches);
+        exec(sprintf($cmd, $repo), $branches);
 
         return $branches;
     }

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -81,8 +81,9 @@
                 </sui-form-field>
                 <sui-form-field :width="4" :error="'source_branch' in errors">
                     <label>Branch</label>
-                    <sui-dropdown selection placeholder="Select branch..." :loading="loadingBranches"
-                        :options="branches" v-model="tmpSite.source_branch" />
+                    <sui-dropdown search selection :loading="loadingBranches"
+                        :options="branches" v-model="tmpSite.source_branch"
+                        placeholder="Select branch..." />
                     <sui-label basic color="red" pointing v-if="'source_branch' in errors">
                         {{ errors.source_branch[0] }}
                     </sui-label>

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -81,7 +81,7 @@
                 </sui-form-field>
                 <sui-form-field :width="4" :error="'source_branch' in errors">
                     <label>Branch</label>
-                    <sui-input v-model="tmpSite.source_branch" />
+                    <sui-dropdown selection placeholder="Select branch..." :options="branches" />
                     <sui-label basic color="red" pointing v-if="'source_branch' in errors">
                         {{ errors.source_branch[0] }}
                     </sui-label>
@@ -117,7 +117,7 @@
 </style>
 
 <script>
-import { mapState } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 import Alerts from '../Alerts';
 
 export default {
@@ -135,6 +135,9 @@ export default {
             'alerts': state => state.sites.alerts,
             'errors': state => state.sites.errors,
             'tmpSite': state => state.sites.current,
+        }),
+        ...mapGetters({
+            'branches': 'sites/branchOptions',
         }),
     },
     watch: {

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -81,7 +81,7 @@
                 </sui-form-field>
                 <sui-form-field :width="4" :error="'source_branch' in errors">
                     <label>Branch</label>
-                    <sui-dropdown selection placeholder="Select branch..."
+                    <sui-dropdown selection placeholder="Select branch..." :loading="loadingBranches"
                         :options="branches" v-model="tmpSite.source_branch" />
                     <sui-label basic color="red" pointing v-if="'source_branch' in errors">
                         {{ errors.source_branch[0] }}
@@ -136,6 +136,7 @@ export default {
             'alerts': state => state.sites.alerts,
             'errors': state => state.sites.errors,
             'tmpSite': state => state.sites.current,
+            'loadingBranches': state => state.sites.branchesLoading,
         }),
         ...mapGetters({
             'branches': 'sites/branchOptions',

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -74,7 +74,7 @@
             <sui-form-fields v-if="tmpSite.type && tmpSite.type != 'redirect'">
                 <sui-form-field :width="12" :error="'source_repo' in errors">
                     <label>Clone URL</label>
-                    <sui-input v-model="tmpSite.source_repo" />
+                    <sui-input v-model="tmpSite.source_repo" @change="refreshBranches(tmpSite.source_repo)" />
                     <sui-label basic color="red" pointing v-if="'source_repo' in errors">
                         {{ errors.source_repo[0] }}
                     </sui-label>
@@ -118,7 +118,7 @@
 </style>
 
 <script>
-import { mapGetters, mapState } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 import Alerts from '../Alerts';
 
 export default {
@@ -152,6 +152,9 @@ export default {
         };
     },
     methods: {
+        ...mapActions({
+            refreshBranches: 'sites/loadBranches',
+        }),
         updateSite(id) {
             this.$store.dispatch('sites/update', {id, data: this.tmpSite});
         },

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -81,7 +81,8 @@
                 </sui-form-field>
                 <sui-form-field :width="4" :error="'source_branch' in errors">
                     <label>Branch</label>
-                    <sui-dropdown selection placeholder="Select branch..." :options="branches" />
+                    <sui-dropdown selection placeholder="Select branch..."
+                        :options="branches" v-model="tmpSite.source_branch" />
                     <sui-label basic color="red" pointing v-if="'source_branch' in errors">
                         {{ errors.source_branch[0] }}
                     </sui-label>

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -78,15 +78,23 @@ export default {
                 }).catch(error => reject(error))
             );
         },
-        edit: ({commit, state}, site) => {
-            commit('setEditorSite', site);
+        loadBranches: ({commit, state}, repo = '') => {
+            let url = '/api/sites/' + state.current.id + '/branches';
+
+            if (repo != '') {
+                url += '?repo=' + repo;
+            }
 
             return new Promise((resolve, reject) =>
-                axios.get('/api/sites/'+state.current.id+'/branches').then(response => {
+                axios.get(url).then(response => {
                     commit('setSiteBranches', response.data);
                     resolve(response);
                 }).catch(error => reject(error))
             );
+        },
+        edit: ({commit, dispatch, state}, site) => {
+            commit('setEditorSite', site);
+            dispatch('loadBranches');
         },
         create: ({commit, state}) => {
             return new Promise((resolve, reject) =>

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -2,6 +2,10 @@ export default {
     namespaced: true,
     state: {
         alerts: [],
+        branches: [
+            'master',
+            'develop',
+        ],
         current: {},
         currentFilter: '',
         errors: [],
@@ -143,6 +147,11 @@ export default {
         },
         findByDocroot: (state) => (path) => {
             return state.sites.find(s => s.document_root == path);
+        },
+        branchOptions: (state) => {
+            return state.branches.map(b => {
+                return { text: b, value: b };
+            });
         },
     },
 }

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -3,6 +3,7 @@ export default {
     state: {
         alerts: [],
         branches: [],
+        branchesLoading: false,
         current: {},
         currentFilter: '',
         errors: [],
@@ -53,6 +54,10 @@ export default {
         },
         setSiteBranches: (state, branches) => {
             state.branches = branches;
+            state.branchesLoading = false;
+        },
+        branchesLoading: (state) => {
+            state.branchesLoading = true;
         },
         addSite: (state, site) => {
             state.sites.push(site);
@@ -79,6 +84,7 @@ export default {
             );
         },
         loadBranches: ({commit, state}, repo = '') => {
+            commit('branchesLoading');
             let url = '/api/sites/' + state.current.id + '/branches';
 
             if (repo != '') {

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -2,10 +2,7 @@ export default {
     namespaced: true,
     state: {
         alerts: [],
-        branches: [
-            'master',
-            'develop',
-        ],
+        branches: [],
         current: {},
         currentFilter: '',
         errors: [],
@@ -54,6 +51,9 @@ export default {
 
             state.current = site;
         },
+        setSiteBranches: (state, branches) => {
+            state.branches = branches;
+        },
         addSite: (state, site) => {
             state.sites.push(site);
             state.site.name = '';
@@ -78,8 +78,15 @@ export default {
                 }).catch(error => reject(error))
             );
         },
-        edit: ({commit}, site) => {
+        edit: ({commit, state}, site) => {
             commit('setEditorSite', site);
+
+            return new Promise((resolve, reject) =>
+                axios.get('/api/sites/'+state.current.id+'/branches').then(response => {
+                    commit('setSiteBranches', response.data);
+                    resolve(response);
+                }).catch(error => reject(error))
+            );
         },
         create: ({commit, state}) => {
             return new Promise((resolve, reject) =>

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::middleware('auth:api')->group(function () {
     Route::resource('sites', 'SiteController', [
         'only' => ['index', 'store', 'update', 'destroy'],
     ]);
+    Route::get('sites/{site}/branches', 'SiteController@branches');
     Route::post('sites/{site}/pull', 'SiteController@pull');
 
     Route::resource('databases', 'DatabaseController', [


### PR DESCRIPTION
Adds a dropdown to the Site Editor that lists branches for selection instead of manually typing the name of a branch into an input. The options are updated any time the `source_repo` field is changed to make sure we're setting the branches from the right repository.

Branches are listed by running `git ls-remote` from a new API endpoint `GET sites/:id/branches`. The resulting dropdown can be filtered and will also show loading state while we're waiting for a response from the API.

Closes  #92 