### PR TITLE
File editor fixup

### DIFF
--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -23,7 +23,7 @@
             </sui-menu>
             <sui-segment v-if="file.error == undefined" class="code"
                 attached="bottom" :inverted="darkMode" :loading="loading">
-                <codemirror v-model="file.contents" :options="options"></codemirror>
+                <codemirror v-model="file.contents" :options="options" v-if="!loading" />
             </sui-segment>
 
             <sui-segment class="placeholder" :inverted="darkMode" v-else>

--- a/resources/sass/components/_codemirror.scss
+++ b/resources/sass/components/_codemirror.scss
@@ -12,11 +12,7 @@
         padding: 0;
     }
 
-    .CodeMirror {
-        height: 100% !important;
-    }
-
-    .vue-codemirror {
-        height: calc(100vh - 310px);
+    .CodeMirror, .vue-codemirror {
+        height: 100%;
     }
 }

--- a/resources/sass/pages/_file-manager.scss
+++ b/resources/sass/pages/_file-manager.scss
@@ -30,11 +30,8 @@
 }
 
 #file-editor {
-    .ui.segment.loading {
-        min-height: 500px;
-    }
-    pre {
-        margin: 0;
-        overflow: auto;
+    .ui.code.segment {
+        height: calc(100vh - 310px);
+        min-height: 310px;
     }
 }


### PR DESCRIPTION
Makes sure the file content isn't visible while the file is actually loading, and updates the height to be set on the parent to fix issues with height being different while loading.