### PR TITLE
File MIME checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Brand-spanking new file viewer using CodeMirror for themes etc
 * Databases can finally be created and listed on the Databases page
 * Current branches for a Site's repo are now listed in a dropdown
+* Files are now checked for a text MIME type before loading contents
 
 ### Changed
 * Stats bar updated to refresh every 60s while the tab is visible

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -90,7 +90,7 @@ class FileManager
 
         $data = [
             'filename' => $file->getFilename(),
-            'mimetype' => mime_content_type($file->getRealPath()),
+            'mimetype' => @mime_content_type($file->getRealPath()),
             'isDir' => $file->isDir(),
             'isFile' => $file->isFile(),
             'isLink' => $file->isLink(),
@@ -124,7 +124,7 @@ class FileManager
     {
         list($file, $data) = $this->loadFile($file);
 
-        if ('text/' != mb_substr($data['mimetype'], 0, 5)) {
+        if ($data['mimetype'] && 'text/' != mb_substr($data['mimetype'], 0, 5)) {
             return array_merge($data, ['error' => [
                 'code' => 415,
                 'msg' => 'Unsupported filetype',

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -90,6 +90,7 @@ class FileManager
 
         $data = [
             'filename' => $file->getFilename(),
+            'mimetype' => mime_content_type($file->getRealPath()),
             'isDir' => $file->isDir(),
             'isFile' => $file->isFile(),
             'isLink' => $file->isLink(),
@@ -122,6 +123,13 @@ class FileManager
     private function fileWithContents($file): array
     {
         list($file, $data) = $this->loadFile($file);
+
+        if ('text/' != mb_substr($data['mimetype'], 0, 5)) {
+            return array_merge($data, [
+                'code' => 415,
+                'msg' => 'Unsupported filetype',
+            ]);
+        }
 
         try {
             $data['contents'] = $file->getContents();

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -125,10 +125,10 @@ class FileManager
         list($file, $data) = $this->loadFile($file);
 
         if ('text/' != mb_substr($data['mimetype'], 0, 5)) {
-            return array_merge($data, [
+            return array_merge($data, ['error' => [
                 'code' => 415,
                 'msg' => 'Unsupported filetype',
-            ]);
+            ]]);
         }
 
         try {

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -30,6 +30,7 @@
                 <sui-header icon>
                     <sui-icon v-if="file.error.code == 403" name="ban" color="red" />
                     <sui-icon v-else-if="file.error.code == 404" name="search" color="teal" />
+                    <sui-icon v-else-if="file.error.code == 415" name="help circle" color="violet" />
                     <sui-icon v-else name="bug" color="orange" />
                     {{ file.error.msg }}
                 </sui-header>

--- a/tests/Unit/FileManager/FileManagerTest.php
+++ b/tests/Unit/FileManager/FileManagerTest.php
@@ -27,6 +27,7 @@ class FileManagerTest extends TestCase
 
         $this->assertSame([
             'filename' => 'another-dir',
+            'mimetype' => 'directory',
             'isDir' => true,
             'isFile' => false,
             'isLink' => false,
@@ -154,6 +155,7 @@ class FileManagerTest extends TestCase
 
         $this->assertSame([
             'filename' => 'hello.md',
+            'mimetype' => 'text/plain',
             'isDir' => false,
             'isFile' => true,
             'isLink' => false,


### PR DESCRIPTION
Adds very basic support for checking a file's detected MIME type before attempting to get the contents of something we can't display, such as an image.

Closes #103 