### PR TITLE
Split pathbar into linked segments on the file editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Files can now actually be edited and saved in the editor
+* Path bar sections are now also clickable in the file viewer
 
 ### Fixed
 * Version info in footer no longer scrolls with content on long pages

--- a/resources/js/components/Files/Browser/FileList.vue
+++ b/resources/js/components/Files/Browser/FileList.vue
@@ -9,27 +9,22 @@
             </tr>
         </thead>
         <tbody>
-            <file-row v-for="file in files" :key="file.id" :file="file"
-                :path="currentPath" @cd="$emit('cd', $event)" />
+            <file-row v-for="file in files" :key="file.id"
+                :file="file" :path="path" />
         </tbody>
     </sui-table>
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
 import FileRow from './FileRow';
 
 export default {
     props: [
         'files',
+        'path',
     ],
     components: {
         FileRow,
-    },
-    computed: {
-        ...mapGetters({
-            currentPath: 'files/currentPath',
-        }),
     },
 }
 </script>

--- a/resources/js/components/Files/Browser/FileList.vue
+++ b/resources/js/components/Files/Browser/FileList.vue
@@ -10,7 +10,7 @@
         </thead>
         <tbody>
             <file-row v-for="file in files" :key="file.id" :file="file"
-                :path="currentPath" @cd="$emit('set-path', $event)" />
+                :path="currentPath" @cd="$emit('cd', $event)" />
         </tbody>
     </sui-table>
 </template>

--- a/resources/js/components/Files/Browser/FileRow.vue
+++ b/resources/js/components/Files/Browser/FileRow.vue
@@ -14,8 +14,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
-
 export default {
     props: [
         'file',
@@ -42,20 +40,18 @@ export default {
             }
         },
         open: function () {
+            let prefix = this.path == '/' ? '' : this.path,
+                target = prefix + '/' + this.file.filename,
+                route = { name: 'files' };
+
             if (this.file.isFile) {
-                return this.$router.push({
-                    name: 'files.edit',
-                    query: {
-                        f: this.path + '/' + this.file.filename,
-                    },
-                });
+                route.name = 'files.edit';
+                route.query = { f: target };
+            } else {
+                route.params = { path: target };
             }
 
-            if (!this.file.isDir) {
-                return;
-            }
-
-            this.$emit('cd', this.file)
+            this.$router.push(route);
         },
     },
 }

--- a/resources/js/components/Files/PathBar.vue
+++ b/resources/js/components/Files/PathBar.vue
@@ -1,0 +1,46 @@
+<template>
+    <sui-breadcrumb class="massive">
+        <template v-for="(segment, index) in pathParts">
+
+            <sui-breadcrumb-section link @click="$emit('cd', segment.path)"
+                v-if="segment.path != path">
+                {{ segment.dirname }}
+            </sui-breadcrumb-section>
+            <sui-breadcrumb-section v-else>
+                {{ segment.dirname }}
+            </sui-breadcrumb-section>
+
+            <sui-breadcrumb-divider @click="$emit('cd', segment.path)"
+                v-if="index < (pathParts.length - 1)" />
+
+        </template>
+    </sui-breadcrumb>
+</template>
+
+<script>
+export default {
+    props: {
+        path: {
+            type: String,
+            default: '',
+        },
+    },
+    computed: {
+        pathParts: function() {
+            let parts = [],
+                path = '';
+
+            for (let part of this.path.split('/')) {
+                path = path + part + '/';
+
+                parts.push({
+                    'path': path.replace(/\/+$/, ''),
+                    'dirname': part,
+                });
+            }
+
+            return parts;
+        },
+    },
+}
+</script>

--- a/resources/js/components/Files/PathBar.vue
+++ b/resources/js/components/Files/PathBar.vue
@@ -1,25 +1,35 @@
 <template>
-    <sui-breadcrumb class="massive">
-        <template v-for="(segment, index) in pathParts">
+    <h2>
+        <sui-button id="levelup" :icon="upIcon" @click="$emit('back')" />
 
-            <sui-breadcrumb-section link @click="$emit('cd', segment.path)"
-                v-if="segment.path != path">
-                {{ segment.dirname }}
-            </sui-breadcrumb-section>
-            <sui-breadcrumb-section v-else>
-                {{ segment.dirname }}
-            </sui-breadcrumb-section>
+        <sui-breadcrumb class="massive">
+            <template v-for="(segment, index) in pathParts">
 
-            <sui-breadcrumb-divider @click="$emit('cd', segment.path)"
-                v-if="index < (pathParts.length - 1)" />
+                <sui-breadcrumb-section v-if="segment.path != path"
+                    link @click="$emit('cd', segment.path)">
+                    {{ segment.dirname }}
+                </sui-breadcrumb-section>
+                <sui-breadcrumb-section v-else>
+                    {{ segment.dirname }}
+                </sui-breadcrumb-section>
 
-        </template>
-    </sui-breadcrumb>
+                <sui-breadcrumb-divider @click="$emit('cd', segment.path)"
+                    v-if="index < (pathParts.length - 1)" />
+
+            </template>
+        </sui-breadcrumb>
+
+        <slot />
+    </h2>
 </template>
 
 <script>
 export default {
     props: {
+        upIcon: {
+            type: String,
+            default: 'level up',
+        },
         path: {
             type: String,
             default: '',

--- a/resources/js/components/Files/PathBar.vue
+++ b/resources/js/components/Files/PathBar.vue
@@ -1,6 +1,6 @@
 <template>
     <h2>
-        <sui-button id="levelup" :icon="upIcon" @click="$emit('back')" />
+        <sui-button id="levelup" :icon="upIcon" @click="goUp()" />
 
         <sui-breadcrumb class="massive">
             <template v-for="(segment, index) in pathParts">
@@ -54,8 +54,12 @@ export default {
     },
     methods: {
         goTo: function (path) {
-            path = path == '' ? '/' : path;
-            this.$router.push({ name: 'files', params: { path } });
+            this.$router.push({ name: 'files', params: {
+                path: path ? path : '/',
+            }});
+        },
+        goUp: function () {
+            this.goTo(this.path.substr(0, this.path.lastIndexOf('/')));
         },
     },
 }

--- a/resources/js/components/Files/PathBar.vue
+++ b/resources/js/components/Files/PathBar.vue
@@ -6,14 +6,14 @@
             <template v-for="(segment, index) in pathParts">
 
                 <sui-breadcrumb-section v-if="segment.path != path"
-                    link @click="$emit('cd', segment.path)">
+                    link @click="goTo(segment.path)">
                     {{ segment.dirname }}
                 </sui-breadcrumb-section>
                 <sui-breadcrumb-section v-else>
                     {{ segment.dirname }}
                 </sui-breadcrumb-section>
 
-                <sui-breadcrumb-divider @click="$emit('cd', segment.path)"
+                <sui-breadcrumb-divider @click="goTo(segment.path)"
                     v-if="index < (pathParts.length - 1)" />
 
             </template>
@@ -50,6 +50,12 @@ export default {
             }
 
             return parts;
+        },
+    },
+    methods: {
+        goTo: function (path) {
+            path = path == '' ? '/' : path;
+            this.$router.push({ name: 'files', params: { path } });
         },
     },
 }

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -1,7 +1,7 @@
 <template>
     <sui-grid container>
         <sui-grid-column id="file-browser">
-            <path-bar :path="currentPath" @back="upOneLevel">
+            <path-bar :path="currentPath">
                 <router-link :to="{ name: 'apps.view', params: { id: site.id }}"
                     is="sui-button" color="teal" icon="globe" floated="right"
                     id="back2site" content="View Application" v-if="site"
@@ -45,15 +45,5 @@ export default {
             return this.findSite(this.currentPath);
         },
     },
-    methods: {
-        upOneLevel: function () {
-            let path = this.currentPath;
-            let next = path.substr(0, path.lastIndexOf('/'));
-            next = next ? next : '/';
-
-            this.$router.push({ name: 'files', params: { path: next } });
-            this.$store.dispatch('files/load', { path: next });
-        },
-    }
 }
 </script>

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -1,7 +1,7 @@
 <template>
     <sui-grid container>
         <sui-grid-column id="file-browser">
-            <path-bar :path="currentPath" @back="upOneLevel" @cd="setPath($event)">
+            <path-bar :path="currentPath" @back="upOneLevel">
                 <router-link :to="{ name: 'apps.view', params: { id: site.id }}"
                     is="sui-button" color="teal" icon="globe" floated="right"
                     id="back2site" content="View Application" v-if="site"
@@ -9,7 +9,7 @@
                     data-position="left center" />
             </path-bar>
 
-            <file-list :files="files" @cd="setPath($event)" />
+            <file-list :files="files" :path="currentPath" />
         </sui-grid-column>
     </sui-grid>
 </template>
@@ -46,16 +46,6 @@ export default {
         },
     },
     methods: {
-        setPath: function (target) {
-            if (typeof target == 'string') {
-                target = '' == target ? '/' : target;
-            } else {
-                target = this.currentPath == '/' ? '/' + target.filename
-                     : this.currentPath + '/' + target.filename
-            }
-
-            this.$router.push({ name: 'files', params: { path: target } });
-        },
         upOneLevel: function () {
             let path = this.currentPath;
             let next = path.substr(0, path.lastIndexOf('/'));

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -1,17 +1,13 @@
 <template>
     <sui-grid container>
         <sui-grid-column id="file-browser">
-            <h2>
+            <path-bar :path="currentPath" @back="upOneLevel" @cd="setPath($event)">
                 <router-link :to="{ name: 'apps.view', params: { id: site.id }}"
                     is="sui-button" color="teal" icon="globe" floated="right"
                     id="back2site" content="View Application" v-if="site"
                     :data-tooltip="'Open overview for ' + site.name"
                     data-position="left center" />
-
-                <sui-button id="levelup" icon="level up" @click="upOneLevel" />
-
-                <path-bar :path="currentPath" @cd="setPath($event)" />
-            </h2>
+            </path-bar>
 
             <file-list :files="files" @cd="setPath($event)" />
         </sui-grid-column>

--- a/resources/js/pages/Files/Browser.vue
+++ b/resources/js/pages/Files/Browser.vue
@@ -10,25 +10,10 @@
 
                 <sui-button id="levelup" icon="level up" @click="upOneLevel" />
 
-                <sui-breadcrumb class="massive">
-                    <template v-for="(segment, index) in pathParts">
-
-                        <sui-breadcrumb-section link @click="setPath(segment.path)"
-                            v-if="segment.path != currentPath">
-                            {{ segment.dirname }}
-                        </sui-breadcrumb-section>
-                        <sui-breadcrumb-section v-else>
-                            {{ segment.dirname }}
-                        </sui-breadcrumb-section>
-
-                        <sui-breadcrumb-divider @click="setPath(segment.path)"
-                            v-if="index < (pathParts.length - 1)" />
-
-                    </template>
-                </sui-breadcrumb>
+                <path-bar :path="currentPath" @cd="setPath($event)" />
             </h2>
 
-            <file-list :files="files" @set-path="setPath($event)" />
+            <file-list :files="files" @cd="setPath($event)" />
         </sui-grid-column>
     </sui-grid>
 </template>
@@ -36,6 +21,7 @@
 <script>
 import { mapGetters, mapMutations } from 'vuex';
 import FileList from '../../components/Files/Browser/FileList';
+import PathBar from '../../components/Files/PathBar';
 
 export default {
     mounted () {
@@ -51,6 +37,7 @@ export default {
     ],
     components: {
         FileList,
+        PathBar,
     },
     computed: {
         ...mapGetters({
@@ -58,21 +45,6 @@ export default {
             findSite: 'sites/findByDocroot',
             files: 'files/all',
         }),
-        pathParts: function() {
-            let parts = [],
-                path = '';
-
-            for (let part of this.currentPath.split('/')) {
-                path = path + part + '/';
-
-                parts.push({
-                    'path': path.replace(/\/+$/, ''),
-                    'dirname': part,
-                });
-            }
-
-            return parts;
-        },
         site: function() {
             return this.findSite(this.currentPath);
         },

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -1,7 +1,7 @@
 <template>
     <sui-grid container>
         <sui-grid-column id="file-editor">
-            <path-bar :path="filePath" upIcon="chevron left" @back="backToDir">
+            <path-bar :path="filePath" upIcon="chevron left">
                 <sui-button positive floated="right" content="Save" @click="save(filePath)" />
             </path-bar>
 
@@ -105,14 +105,6 @@ export default {
         ...mapActions({
             save: 'files/save',
         }),
-        backToDir: function () {
-            let path = this.filePath;
-
-            this.$router.push({
-                name: 'files',
-                params: { path: path.substr(0, path.lastIndexOf('/')) },
-            });
-        },
     },
 }
 </script>

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -3,7 +3,7 @@
         <sui-grid-column id="file-editor">
             <h2>
                 <sui-button id="levelup" icon="chevron left" @click="backToDir" />
-                <span class="pathbar">{{ filePath }}</span>
+                <path-bar :path="filePath" @cd="browse($event)" />
                 <sui-button positive floated="right" content="Save" @click="save(filePath)" />
             </h2>
 
@@ -43,12 +43,14 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { codemirror } from 'vue-codemirror'
+import PathBar from '../../components/Files/PathBar';
 import 'codemirror/lib/codemirror.css'
 import 'codemirror/theme/dracula.css'
 
 export default {
     components: {
         codemirror,
+        PathBar,
     },
     async mounted () {
         this.loading = true;
@@ -112,6 +114,11 @@ export default {
                 name: 'files',
                 params: { path: path.substr(0, path.lastIndexOf('/')) },
             });
+        },
+        browse: function (to) {
+            this.$router.push({ name: 'files', params: {
+                path: to == '' ? '/' : to,
+            }});
         },
     },
 }

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -1,11 +1,9 @@
 <template>
     <sui-grid container>
         <sui-grid-column id="file-editor">
-            <h2>
-                <sui-button id="levelup" icon="chevron left" @click="backToDir" />
-                <path-bar :path="filePath" @cd="browse($event)" />
+            <path-bar :path="filePath" upIcon="chevron left" @back="backToDir" @cd="browse($event)">
                 <sui-button positive floated="right" content="Save" @click="save(filePath)" />
-            </h2>
+            </path-bar>
 
             <sui-menu attached="top" v-if="file.error == undefined" :inverted="darkMode">
                 <sui-dropdown item class="icon" icon="paint brush"

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -1,7 +1,7 @@
 <template>
     <sui-grid container>
         <sui-grid-column id="file-editor">
-            <path-bar :path="filePath" upIcon="chevron left" @back="backToDir" @cd="browse($event)">
+            <path-bar :path="filePath" upIcon="chevron left" @back="backToDir">
                 <sui-button positive floated="right" content="Save" @click="save(filePath)" />
             </path-bar>
 
@@ -112,11 +112,6 @@ export default {
                 name: 'files',
                 params: { path: path.substr(0, path.lastIndexOf('/')) },
             });
-        },
-        browse: function (to) {
-            this.$router.push({ name: 'files', params: {
-                path: to == '' ? '/' : to,
-            }});
         },
     },
 }


### PR DESCRIPTION
This moves the file editor's path bar code into a new `PathBar` component which is now also used in the file viewer.

Initially I'd left the directory change handling bits in place, but with it being called from 3 or 4 places with largely the same code with the exception of slightly different paths it made sense to move those into the component too.

To support that, the `open` method in the file row has also been updated to handle opening directories instead of only files.

Fixes #185 