### PR TITLE
Login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Login form no longer breaks out of the layout to full page width
+* Stats bar no longer polls for data after logging out
 
 
 ## [0.7.0] - 2019-12-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+* Login form no longer breaks out of the layout to full page width
 
 
 ## [0.7.0] - 2019-12-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+* Login page is now styled to match dark mode
+
 ### Fixed
 * Login form no longer breaks out of the layout to full page width
 * Stats bar no longer polls for data after logging out

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -48,6 +48,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
+
 export default {
     data () {
         return {
@@ -86,8 +88,16 @@ export default {
             document.removeEventListener("visibilitychange", startStopRefreshStatsBar);
         });
     },
+    computed: {
+        ...mapGetters([
+            'loggedIn',
+        ]),
+    },
     methods: {
         initStatsBar () {
+            if (!this.loggedIn) {
+                return;
+            }
             axios.get('/api/system-info').then(response => {
                 let data = response.data;
 

--- a/resources/js/pages/Auth/Login.vue
+++ b/resources/js/pages/Auth/Login.vue
@@ -45,6 +45,7 @@
                 </router-link>
             </div>
         </div>
+        <link href="/css/app.css" rel="stylesheet" type="text/css">
     </div>
 </template>
 

--- a/resources/js/pages/Auth/Login.vue
+++ b/resources/js/pages/Auth/Login.vue
@@ -1,18 +1,18 @@
 <template>
     <div class="ui middle aligned center aligned grid">
         <div class="column">
-            <h2 class="ui teal header centered">
+            <h2 class="ui header centered">
                 <i class="server icon"></i>
                 Sign in to Servidor
             </h2>
             <form class="ui form" @submit.prevent="login" method="POST" action="/login">
-                <div class="ui stacked segment">
+                <div class="ui inverted stacked segment">
                     <sui-message negative v-if="error.msg"
                         :header="error.title"
                         :content="error.msg" />
 
                     <div class="field">
-                        <div class="ui left icon input" type="email" placeholder="Email address">
+                        <div class="ui left inverted transparent icon input" type="email" placeholder="Email address">
                             <input id="email" type="email" name="email"
                                 v-model="username" placeholder="E-mail address"
                                 required autofocus>
@@ -20,7 +20,7 @@
                         </div>
                     </div>
                     <div class="field">
-                        <div class="ui left icon input" type="password" placeholder="Password">
+                        <div class="ui left inverted transparent icon input" type="password" placeholder="Password">
                             <input id="password" type="password" name="password"
                                 v-model="password" required
                                 placeholder="Password" />
@@ -33,19 +33,21 @@
                             <label for="remember">Remember Me</label>
                         </div>
                     </div>
-                    <button class="ui teal fluid large button" type="submit">
+                    <button class="ui positive fluid large button" type="submit">
                         Login
                     </button>
                 </div>
             </form>
 
-            <div class="ui message">
+            <div class="ui inverted message">
                 <router-link :to="{ name: 'password.request' }" class="centered">
                     Forgot Your Password?
                 </router-link>
             </div>
         </div>
+        <link v-if="darkMode" href="/css/dark-theme.css" rel="stylesheet" type="text/css">
         <link href="/css/app.css" rel="stylesheet" type="text/css">
+        <link v-if="darkMode" href="/css/dark-theme.custom.css" rel="stylesheet" type="text/css">
     </div>
 </template>
 

--- a/resources/sass/pages/_login.scss
+++ b/resources/sass/pages/_login.scss
@@ -5,8 +5,8 @@ body.login {
     .grid {
         height: 100%;
     }
-    .column {
-        max-width: 450px;
+    .ui.grid > .column:not(.row) {
+        width: 450px;
     }
 
     .field[class*="left aligned"] {

--- a/resources/sass/pages/_login.scss
+++ b/resources/sass/pages/_login.scss
@@ -1,5 +1,5 @@
 body.login {
-    background: #dedede;
+    background: #2b3e50;
     margin-top: 5em;
 
     .grid {
@@ -7,6 +7,37 @@ body.login {
     }
     .ui.grid > .column:not(.row) {
         width: 450px;
+
+        .ui.inverted.segment,
+        .ui.inverted.message {
+            background: rgba(27, 28, 29, 0.3);
+        }
+
+        .ui.form input {
+            color: rgba(255, 255, 255, 0.6);
+
+            &:focus {
+                color: #fff;
+            }
+        }
+        .ui.toggle.checkbox {
+            label {
+                &::before {
+                    background: rgba(0, 0, 0, 0.3);
+                }
+                &::after {
+                    background: rgba(227, 230, 233, 0.7) linear-gradient(
+                        transparent, rgba(0, 0, 0, 0.05));
+                }
+            }
+
+            input:checked ~ label {
+                color: #fff !important;
+            }
+        }
+        /*.ui.form input {
+            background: rgba(255, 255, 255, 0.1);
+        }*/
     }
 
     .field[class*="left aligned"] {


### PR DESCRIPTION
Fixes missing styles from the Blade to Vue conversion in the login page that caused the styles to not be loaded, and updates the `.column` rule to be more specific so that it gets applied.

Also converts the overall styling of the login page to match that of dark mode once logged in.

![image](https://user-images.githubusercontent.com/1521802/71703863-f713bc00-2dce-11ea-8257-21510be18ed8.png)
