### PR TITLE
Site logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * File contents no longer have whitespace and newlines trimmed when saved
 * Listing a directory that doesn't exist will now show a friendly error
+* Updating sites now correctly creates docroot when it doesn't already exist
 
 
 ## [0.8.0] - 2020-02-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Deleting system users and groups now triggers a confirmation prompt
 * Home directory can now be purged when deleting a system user
 * File Manager now supports creating, renaming and deleting dirs and files
+* Site overview now supports viewing logs for the site and related services
 
 ### Fixed
 * File contents no longer have whitespace and newlines trimmed when saved

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ eslint:
 	node_modules/.bin/eslint -c build/eslint/config.json "resources/js/**/*.{js,vue}"
 
 phpstan:
-	vendor/bin/phpstan analyze -c build/phpstan/config.neon
+	php -d memory_limit=-1 vendor/bin/phpstan analyze -c build/phpstan/config.neon
 
 psalm:
 	vendor/bin/psalm -c build/psalm/psalm.xml

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ test:
 	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
 
 coverage:
-	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml --coverage-text"
+	@vagrant ssh -c "cd /var/servidor && sudo -u www-data php vendor/bin/phpunit -c build/phpunit/config.xml --coverage-text"
 	@echo
 
 coverage-html:
-	vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml --coverage-html tests/reports/coverage/latest"
+	vagrant ssh -c "cd /var/servidor && sudo -u www-data php vendor/bin/phpunit -c build/phpunit/config.xml --coverage-html tests/reports/coverage/latest"
 	@mv tests/reports/coverage/latest tests/reports/coverage/$(now)/ && xdg-open ./tests/reports/coverage/$(now)/index.html
 	@echo
 

--- a/app/Http/Controllers/DatabaseController.php
+++ b/app/Http/Controllers/DatabaseController.php
@@ -3,6 +3,7 @@
 namespace Servidor\Http\Controllers;
 
 use Exception;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Servidor\Database;
@@ -23,21 +24,19 @@ class DatabaseController extends Controller
 
     /**
      * Create a new database.
-     *
-     * @return \Illuminate\Contracts\Routing\ResponseFactory|Response
      */
-    public function store(Request $request)
+    public function store(Request $request): JsonResponse
     {
         $data = $request->validate([
             'database' => 'required|string',
         ]);
 
-        $created = (new Database())->create($data['database']);
-
-        if (!$created) {
-            throw new Exception('Could not create datbase');
+        try {
+            (new Database())->create($data['database']);
+        } catch (Exception $e) {
+            return response()->json(['error' => 'Could not create database'], 500);
         }
 
-        return response($data['database'], Response::HTTP_OK);
+        return response()->json($data['database']);
     }
 }

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -92,6 +92,15 @@ class SiteController extends Controller
         return response()->json($site, Response::HTTP_OK);
     }
 
+    public function showLog(Site $site, string $log): Response
+    {
+        $path = $site->logs[$log]['path'];
+
+        exec('sudo cat ' . escapeshellarg($path), $content);
+
+        return response()->make(implode("\n", $content));
+    }
+
     /**
      * Update the specified resource in storage.
      */

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -94,11 +94,7 @@ class SiteController extends Controller
 
     public function showLog(Site $site, string $log): Response
     {
-        $path = $site->logs[$log]['path'];
-
-        exec('sudo cat ' . escapeshellarg($path), $content);
-
-        return response()->make(implode("\n", $content));
+        return response()->make($site->readLog($log));
     }
 
     /**

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
-use InvalidArgumentException;
+use Illuminate\Validation\ValidationException;
 use Servidor\Exceptions\System\UserNotFoundException;
 use Servidor\Http\Requests\CreateSite;
 use Servidor\Http\Requests\UpdateSite;
@@ -44,7 +44,7 @@ class SiteController extends Controller
         $cmd = "git ls-remote --heads '%s' | sed 's^.*refs/heads/^^'";
         $repo = $request->query('repo', $site->source_repo);
         if (!$repo || !is_string($repo)) {
-            throw new InvalidArgumentException();
+            throw ValidationException::withMessages(['repo' => 'Missing repo and site does not have one set.']);
         }
 
         exec(sprintf($cmd, $repo), $branches);
@@ -78,8 +78,8 @@ class SiteController extends Controller
             return response()->json($site, Response::HTTP_OK);
         }
 
-        if (!is_dir(dirname($root))) {
-            mkdir(dirname($root));
+        if (!is_dir($root)) {
+            mkdir($root);
         }
 
         $args = $branch ? ' --branch "' . $branch . '"' : '';

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -89,7 +89,7 @@ class WriteSiteConfig
         }
 
         if (!is_dir($root)) {
-            mkdir($root, 755);
+            mkdir($root, 0755, true);
         }
 
         $cloneCmd = $branch ? 'git clone --branch "' . $branch . '"' : 'git clone';

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -59,10 +59,11 @@ class WriteSiteConfig
 
     private function updateConfig(): void
     {
+        $type = $this->site->type ?? 'basic';
         /** @var \Illuminate\View\View */
-        $view = 'laravel' == $this->site->type
+        $view = 'laravel' == $type
             ? view('sites.server-templates.php')
-            : view('sites.server-templates.' . $this->site->type);
+            : view('sites.server-templates.' . $type);
 
         Storage::put('vhosts/' . $this->filename, (string) $view->with('site', $this->site));
 
@@ -87,8 +88,8 @@ class WriteSiteConfig
             return;
         }
 
-        if (!is_dir(dirname($root))) {
-            mkdir(dirname($root), 755);
+        if (!is_dir($root)) {
+            mkdir($root, 755);
         }
 
         $cloneCmd = $branch ? 'git clone --branch "' . $branch . '"' : 'git clone';

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -12,8 +12,8 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Broadcast::routes();
+        // Broadcast::routes();
 
-        require base_path('routes/channels.php');
+        // require base_path('routes/channels.php');
     }
 }

--- a/app/Site.php
+++ b/app/Site.php
@@ -29,7 +29,26 @@ class Site extends Model
         'is_enabled',
     ];
 
-    public function getSystemUserAttribute(): ?array
+    public function getLogsAttribute(): array
+    {
+        $defaultPhp = sprintf('/var/log/php%d.%d-fpm.log', PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+        $php = ['name' => 'PHP Error Log', 'path' => ini_get('error_log') ?: $defaultPhp];
+        $laravel = ['name' => 'Laravel Log', 'path' => 'storage/logs/laravel.log'];
+
+        switch ($this->attributes['type'] ?? '') {
+            case 'laravel':
+                return compact('php', 'laravel');
+            case 'php':
+                return compact('php');
+        }
+
+        return [];
+    }
+
+    /**
+     * @return int|array|null
+     */
+    public function getSystemUserAttribute()
     {
         $uid = $this->attributes['system_user'];
 
@@ -42,5 +61,10 @@ class Site extends Model
         } catch (UserNotFoundException $e) {
             return null;
         }
+    }
+
+    public function setSystemUserAttribute(int $uid): void
+    {
+        $this->attributes['system_user'] = $uid;
     }
 }

--- a/app/Site.php
+++ b/app/Site.php
@@ -9,6 +9,8 @@ use Servidor\System\User as SystemUser;
 
 class Site extends Model
 {
+    protected $appends = ['logs'];
+
     protected $casts = [
         'is_enabled' => 'boolean',
     ];

--- a/app/Site.php
+++ b/app/Site.php
@@ -3,6 +3,7 @@
 namespace Servidor;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Servidor\Events\SiteUpdated;
 use Servidor\Exceptions\System\UserNotFoundException;
 use Servidor\System\User as SystemUser;
@@ -45,6 +46,17 @@ class Site extends Model
         }
 
         return [];
+    }
+
+    public function readLog(string $log): string
+    {
+        $path = Str::startsWith($this->logs[$log]['path'], '/') ? '' : (
+            Str::beforeLast($this->document_root, '/public') . '/'
+        ) . $this->logs[$log]['path'];
+
+        exec('sudo cat ' . escapeshellarg($path), $file);
+
+        return implode("\n", $file);
     }
 
     /**

--- a/build/travis/install.sh
+++ b/build/travis/install.sh
@@ -16,6 +16,7 @@ npm_install() {
 }
 
 php_install() {
+    pecl install pcov
     mysql -e 'CREATE DATABASE servidor_test;'
 
     travis_retry composer install --no-interaction

--- a/build/travis/install.sh
+++ b/build/travis/install.sh
@@ -19,6 +19,7 @@ php_install() {
     pecl install pcov
     mysql -e 'CREATE DATABASE servidor_test;'
 
+    git config --global pull.ff only
     travis_retry composer install --no-interaction
 
     cp build/travis/dotenv ./.env

--- a/build/travis/nginx.service
+++ b/build/travis/nginx.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Dummy Nginx service for Travis-CI testing
+
+[Service]
+ExecStart=/bin/bash -c "systemctl reset-failed nginx.service; while true; do sleep 1; done"

--- a/build/travis/prepare.sh
+++ b/build/travis/prepare.sh
@@ -5,7 +5,12 @@ main() {
         return
     fi
 
+    svc="${TRAVIS_BUILD_DIR}/build/travis/nginx.service"
     skeleton="${TRAVIS_BUILD_DIR}/resources/test-skel"
+
+    sudo cp "${svc}" /etc/systemd/system/ && sudo systemctl daemon-reload
+    sudo mkdir -p /var/www /etc/nginx/sites-enabled /etc/nginx/sites-available
+    sudo chmod -R 777 /etc/nginx /var/www
 
     sudo chmod 777 "${skeleton}"
     sudo chown -R www-data:www-data "${skeleton}"

--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -23,7 +23,7 @@ test_php() {
         run_php_cs "${scriptDir}"
     fi
 
-    phpdbg -qrr "${scriptDir}/phpunit" -c build/phpunit/config.xml \
+    php "${scriptDir}/phpunit" -c build/phpunit/config.xml \
         --coverage-clover=coverage.xml --exclude-group "broken-travis"
 }
 

--- a/build/vagrant/bootstrap.sh
+++ b/build/vagrant/bootstrap.sh
@@ -20,7 +20,7 @@ install_software() {
     add-apt-repository ppa:ondrej/php
 
     $update && $install mariadb-server nginx openssl sysstat unzip zsh \
-        php7.4-fpm php7.4-bcmath php7.4-json php7.4-mbstring php7.4-mysql php7.4-xml php7.4-zip
+        php7.4-fpm php-pcov php7.4-bcmath php7.4-json php7.4-mbstring php7.4-mysql php7.4-xml php7.4-zip
 
     start_service mariadb
 }

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -130,9 +130,28 @@
                 </sui-header>
             </sui-segment>
 
+            <sui-header attached="top" :inverted="darkMode" v-if="Object.keys(site.logs).length">
+                Project Logs
+            </sui-header>
+            <sui-table selectable class="attached logtable" :inverted="darkMode">
+                <sui-table-body>
+                    <sui-table-row @click="viewLog(log.path)"
+                        v-for="(log, key) in site.logs" :key="key">
+                        <sui-table-cell collapsing>{{ log.name }}</sui-table-cell>
+                        <sui-table-cell>{{ log.path }}</sui-table-cell>
+                    </sui-table-row>
+                </sui-table-body>
+            </sui-table>
+
         </sui-grid-column>
     </sui-grid-row>
 </template>
+
+<style>
+.logtable tr {
+    cursor: pointer;
+}
+</style>
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
@@ -161,6 +180,12 @@ export default {
         ...mapActions({
             pullFiles: 'sites/pull',
         }),
+        viewLog(path) {
+            this.$router.push({
+                name: 'files.edit',
+                query: { f: path },
+            });
+        },
     },
 };
 </script>

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -130,13 +130,13 @@
                 </sui-header>
             </sui-segment>
 
-            <sui-header attached="top" :inverted="darkMode" v-if="Object.keys(site.logs).length">
+            <sui-header attached="top" :inverted="darkMode" v-if="logNames(site).length">
                 Project Logs
             </sui-header>
-            <sui-segment attached :inverted="darkMode" v-if="Object.keys(site.logs).length">
+            <sui-segment attached :inverted="darkMode" v-if="logNames(site).length">
                 <sui-menu pointing secondary :inverted="darkMode">
                     <a is="sui-menu-item" v-for="(log, key) in site.logs" :key="key"
-                        :active="activeLog === key" @click="viewLog(key)"
+                        :active="activeLog === key" @click="viewLog(site.id, key)"
                         :content="log.name" />
                 </sui-menu>
                 <pre>{{ logContent }}</pre>
@@ -174,7 +174,11 @@ export default {
         };
     },
     mounted() {
-        this.viewLog(Object.keys(this.site.logs)[0]);
+        this.initLog(this.site.id);
+    },
+    beforeRouteUpdate(to, from, next) {
+        this.initLog(to.params.id);
+        next();
     },
     computed: {
         ...mapGetters({
@@ -188,8 +192,23 @@ export default {
         ...mapActions({
             pullFiles: 'sites/pull',
         }),
-        viewLog(key) {
-            const id = this.site.id;
+        initLog(siteId) {
+            const logs = this.logNames(siteId);
+
+            if (logs.length) {
+                this.viewLog(siteId, logs[0]);
+            } else {
+                this.logContent = '';
+                this.activeLog = '';
+            }
+        },
+        logNames(site) {
+            const s = 'object' === typeof site ? site
+                : this.findSite(parseInt(site));
+
+            return Object.keys(s.logs);
+        },
+        viewLog(id, key) {
             this.logContent = 'Loading...';
             this.activeLog = key;
 

--- a/resources/test-skel/logrel/storage/logs/laravel.log
+++ b/resources/test-skel/logrel/storage/logs/laravel.log
@@ -1,0 +1,1 @@
+It works!

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::middleware('auth:api')->group(function (): void {
     ]);
     Route::get('sites/{site}/branches', 'SiteController@branches');
     Route::post('sites/{site}/pull', 'SiteController@pull');
+    Route::get('sites/{site}/logs/{log}', 'SiteController@showLog');
 
     Route::resource('databases', 'DatabaseController', [
         'only' => ['index', 'store'],

--- a/tests/Feature/Api/DatabaseTest.php
+++ b/tests/Feature/Api/DatabaseTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Http\Response;
+use Tests\RequiresAuth;
+use Tests\TestCase;
+
+class DatabaseTest extends TestCase
+{
+    use RequiresAuth;
+
+    protected $endpoint = '/api/databases';
+
+    /** @test */
+    public function guest_cannot_list_databases(): void
+    {
+        $response = $this->getJson($this->endpoint);
+
+        $response->assertUnauthorized();
+        $response->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+
+    /** @test */
+    public function authed_user_can_list_databases(): void
+    {
+        $response = $this->authed()->getJson($this->endpoint);
+
+        $response->assertOk();
+        $response->assertJsonFragment(['information_schema']);
+        $response->assertJsonFragment(['performance_schema']);
+        $response->assertJsonFragment(['mysql']);
+    }
+
+    /** @test */
+    public function authed_user_can_create_a_database(): void
+    {
+        $db = 'caniplz';
+        $response = $this->authed()->postJson($this->endpoint, ['database' => $db]);
+
+        $response->assertOk();
+        $this->assertSame($db, $response->json());
+    }
+
+    /** @test */
+    public function creation_fails_when_name_is_invalid(): void
+    {
+        $db = 'some_really_long_name_that_is_so_long_it_really';
+        $db .= '_should_be_split_over_multiple_lines';
+        $response = $this->authed()->postJson($this->endpoint, ['database' => $db]);
+
+        $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
+        $response->assertExactJson(['error' => 'Could not create database']);
+    }
+}

--- a/tests/Feature/Api/Files/DeletePathTest.php
+++ b/tests/Feature/Api/Files/DeletePathTest.php
@@ -41,4 +41,13 @@ class DeletePathTest extends TestCase
 
         $response->assertStatus(Response::HTTP_NO_CONTENT);
     }
+
+    /** @test */
+    public function delete_throws_error_when_file_is_not_given(): void
+    {
+        $response = $this->authed()->deleteJson($this->endpoint(['foo' => 'bar']));
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['file' => 'File path must be specified.']);
+    }
 }

--- a/tests/Feature/Api/Sites/ListSitesTest.php
+++ b/tests/Feature/Api/Sites/ListSitesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Api\Sites;
+
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Servidor\Site;
+use Tests\RequiresAuth;
+use Tests\TestCase;
+
+class ListSitesTest extends TestCase
+{
+    use ArraySubsetAsserts;
+    use RefreshDatabase;
+    use RequiresAuth;
+
+    protected $endpoint = '/api/sites';
+
+    /** @test */
+    public function sites_include_list_of_logs(): void
+    {
+        $site = Site::create(['name' => 'php-site', 'type' => 'php']);
+
+        $response = $this->authed()->getJson($this->endpoint);
+
+        $response->assertOk();
+        $response->assertJsonStructure([['name', 'type', 'logs' => [
+            'php' => ['name', 'path'],
+        ]]]);
+    }
+}

--- a/tests/Feature/Api/Sites/ViewSiteLogsTest.php
+++ b/tests/Feature/Api/Sites/ViewSiteLogsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature\Api\Sites;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Servidor\Site;
+use Tests\RequiresAuth;
+use Tests\TestCase;
+
+class ViewSiteLogsTest extends TestCase
+{
+    use RefreshDatabase;
+    use RequiresAuth;
+
+    /** @test */
+    public function can_retrieve_content_for_site_log(): void
+    {
+        $this->withoutExceptionHandling();
+        $site = Site::create(['name' => 'logtest', 'type' => 'php']);
+
+        $response = $this->authed()->getJson('/api/sites/' . $site->id . '/logs/php');
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/Api/SitesTest.php
+++ b/tests/Feature/Api/SitesTest.php
@@ -39,6 +39,48 @@ class SitesTest extends TestCase
     }
 
     /** @test */
+    public function guest_cannot_list_a_sites_branches(): void
+    {
+        $site = Site::create([
+            'name' => 'Test Site',
+            'type' => 'basic',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+
+        $response = $this->getJson('/api/sites/' . $site->id . '/branches');
+
+        $response->assertJsonCount(1);
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+        $response->assertJson(['message' => 'Unauthenticated.']);
+    }
+
+    /** @test */
+    public function authed_user_can_list_a_sites_branches(): void
+    {
+        $site = Site::create([
+            'name' => 'Test Site',
+            'type' => 'basic',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+
+        $response = $this->authed()->getJson('/api/sites/' . $site->id . '/branches');
+
+        $response->assertOk();
+        $response->assertJson(['develop', 'master']);
+    }
+
+    /** @test */
+    public function listing_branches_requires_site_to_have_a_repo(): void
+    {
+        $site = Site::create(['name' => 'Repoless', 'type' => 'basic']);
+
+        $response = $this->authed()->getJson('/api/sites/' . $site->id . '/branches');
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['repo' => 'Missing repo']);
+    }
+
+    /** @test */
     public function guest_cannot_create_site(): void
     {
         $response = $this->postJson('/api/sites', [
@@ -221,9 +263,7 @@ class SitesTest extends TestCase
         $response->assertOk();
         $this->assertDirectoryExists($dir . '/.git');
 
-        // If we try this in tearDown(), storage_path() complains that
-        // path.storage class can't be found. No idea why, but it does.
-        exec('rm -rf "' . $dir . '"');
+        exec('rm -rf "' . $site->document_root . '"');
     }
 
     /** @test */
@@ -255,6 +295,55 @@ class SitesTest extends TestCase
         $response->assertJsonCount(1);
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
         $response->assertJson(['error' => 'Project is missing its document root!']);
+    }
+
+    /** @test */
+    public function can_checkout_after_initial_pull(): void
+    {
+        $dir = resource_path('test-skel/checkedout');
+        $site = Site::create([
+            'name' => 'Site for checkout',
+            'type' => 'basic',
+            'document_root' => $dir,
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+        $site->update(['is_enabled' => true]);
+
+        $response = $this->authed()->postJson('/api/sites/' . $site->id . '/pull');
+
+        $response->assertOk();
+        $response->assertJsonFragment([
+            'name' => 'Site for checkout',
+            'document_root' => $dir,
+            'is_enabled' => true,
+        ]);
+
+        exec('rm -rf "' . $dir . '"');
+    }
+
+    /** @test */
+    public function pull_creates_docroot_if_it_doesnt_exist(): void
+    {
+        $dir = resource_path('test-skel/makeme');
+        $site = Site::create([
+            'type' => 'basic',
+            'name' => 'Creating Docroot',
+            'document_root' => $dir,
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+        ]);
+
+        $this->assertDirectoryNotExists($dir);
+        $response = $this->authed()->postJson('/api/sites/' . $site->id . '/pull');
+
+        $response->assertOk();
+        $response->assertJsonFragment([
+            'name' => 'Creating Docroot',
+            'document_root' => $dir,
+            'type' => 'basic',
+        ]);
+        $this->assertDirectoryExists($dir);
+
+        exec('rm -rf "' . $dir . '"');
     }
 
     /** @test */

--- a/tests/Feature/Api/SystemInformationTest.php
+++ b/tests/Feature/Api/SystemInformationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Tests\RequiresAuth;
+use Tests\TestCase;
+
+class SystemInformationTest extends TestCase
+{
+    use RequiresAuth;
+
+    /** @test */
+    public function guest_cannot_retrieve_system_stats(): void
+    {
+        $response = $this->getJson('/api/system-info');
+
+        $response->assertUnauthorized();
+        $response->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+
+    /** @test */
+    public function authed_user_can_retrieve_system_stats(): void
+    {
+        $response = $this->authed()->getJson('/api/system-info');
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'cpu',
+            'load_average' => ['1m', '5m', '15m'],
+            'ram' => ['total', 'used', 'free'],
+            'disk' => ['partition', 'total', 'used', 'used_pct', 'free'],
+            'os' => ['name', 'distro', 'version'],
+        ]);
+    }
+}

--- a/tests/Unit/DatabaseTest.php
+++ b/tests/Unit/DatabaseTest.php
@@ -30,7 +30,7 @@ class DatabaseTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_database(): void
+    public function it_can_create_a_database(): Database
     {
         $db = new Database();
         $before = $db->listDatabases();
@@ -40,7 +40,22 @@ class DatabaseTest extends TestCase
         sort($after);
 
         $this->assertTrue($created);
-        $this->assertSame($db->listDatabases(), $after);
+        $this->assertSame($after, $db->listDatabases());
+
+        return $db;
+    }
+
+    /**
+     * @test
+     * @depends it_can_create_a_database
+     */
+    public function it_returns_true_when_created_database_exists(
+        Database $db
+    ): void {
+        $before = $db->listDatabases();
+
+        $this->assertTrue($db->create('testdb'));
+        $this->assertSame($before, $db->listDatabases());
 
         $db->dbal()->dropDatabase('testdb');
     }

--- a/tests/Unit/Listeners/WriteSiteConfigTest.php
+++ b/tests/Unit/Listeners/WriteSiteConfigTest.php
@@ -164,4 +164,27 @@ class WriteSiteConfigTest extends TestCase
         $this->assertDirectoryExists($path);
         exec('rm -rf "' . $path . '"');
     }
+
+    /** @test */
+    public function pull_creates_root_with_correct_permissions(): void
+    {
+        $path = '/var/www/rootperms.example/public';
+        $site = Site::create(['name' => 'rootperms']);
+
+        $this->assertDirectoryNotExists($path);
+        $site->document_root = $path;
+        $site->update([
+            'primary_domain' => 'rootperms.example',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'source_branch' => 'develop',
+            'type' => 'laravel',
+        ]);
+
+        $stat = system("stat -c '%a' \"${path}\"");
+
+        $this->assertDirectoryExists($path);
+        $this->assertEquals(755, $stat);
+
+        exec('rm -rf "' . $path . '"');
+    }
 }

--- a/tests/Unit/Listeners/WriteSiteConfigTest.php
+++ b/tests/Unit/Listeners/WriteSiteConfigTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Unit\Listeners;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Servidor\Site;
+use Tests\TestCase;
+
+class WriteSiteConfigTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function enabling_site_creates_config_symlink(): void
+    {
+        $link = '/etc/nginx/sites-enabled/symlinkery.dev.conf';
+        $target = '/etc/nginx/sites-available/symlinkery.dev.conf';
+
+        $path = resource_path('test-skel/new-project');
+        $this->assertFileNotExists($link);
+        $site = Site::create([
+            'name' => 'symlinkery',
+        ]);
+        $site->update([
+            'document_root' => $path,
+            'primary_domain' => 'symlinkery.dev',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'source_branch' => 'develop',
+            'is_enabled' => true,
+            'type' => 'basic',
+        ]);
+
+        $this->assertTrue(is_link($link));
+        $this->assertFileExists($link);
+        $this->assertEquals($target, readlink($link));
+
+        exec("rm -rf \"{$site->document_root}\"; sudo rm \"{$link}\"");
+    }
+
+    /** @test */
+    public function symlink_is_not_created_when_it_is_valid(): void
+    {
+        $link = '/etc/nginx/sites-enabled/symlinkeroo.dev.conf';
+        $path = resource_path('test-skel/new-project');
+        $site = Site::create(['name' => 'symlinkeroo']);
+
+        $site->update([
+            'document_root' => $path,
+            'primary_domain' => 'symlinkeroo.dev',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'source_branch' => 'develop',
+            'is_enabled' => true,
+            'type' => 'basic',
+        ]);
+
+        $linkBefore = readlink($link);
+        $site->update(['name' => 'symlinkeroo-updated']);
+
+        $this->assertEquals('symlinkeroo-updated', $site->name);
+        $this->assertSame($linkBefore, readlink($link));
+
+        exec("rm -rf \"{$site->document_root}\"; sudo rm \"{$link}\"");
+    }
+
+    /** @test */
+    public function outdated_symlinks_get_replaced(): void
+    {
+        $link = '/etc/nginx/sites-enabled/outdated.dev.conf';
+        $vhost = '/etc/nginx/sites-available/outdated.dev.conf';
+        $path = resource_path('test-skel/outdated-project');
+        $site = Site::create(['name' => 'linkoutdated']);
+
+        $site->document_root = $path;
+        $site->update([
+            'primary_domain' => 'outdated.dev',
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'source_branch' => 'develop',
+            'type' => 'basic',
+        ]);
+
+        exec('sudo ln -s /dev/null "' . $link . '"');
+        $site->update([
+            'is_enabled' => true,
+        ]);
+
+        $this->assertFileExists($link);
+        $this->assertFileExists($vhost);
+        $this->assertTrue(is_link($link));
+        $this->assertEquals($vhost, readlink($link));
+
+        exec("rm -rf \"{$site->document_root}\"; sudo rm \"{$link}\"");
+    }
+
+    /** @test */
+    public function update_defaults_to_basic_project_type(): void
+    {
+        $path = resource_path('test-skel/foo');
+        $site = Site::create(['name' => 'Untitled']);
+
+        $site->document_root = $path;
+        $site->update([
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'primary_domain' => 'basicdefault.example',
+            'source_branch' => 'develop',
+        ]);
+
+        $config = storage_path('app/vhosts/' . $site->primary_domain . '.conf');
+        $this->assertStringContainsString('index index.html index.htm;', file_get_contents($config));
+    }
+
+    /** @test */
+    public function laravel_projects_use_php_nginx_config(): Site
+    {
+        $site = Site::create(['name' => 'laratest']);
+
+        $site->document_root = resource_path('test-skel/larafoo');
+        $site->update([
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'primary_domain' => 'laratest.dev',
+            'source_branch' => 'master',
+            'is_enabled' => true,
+            'type' => 'laravel',
+        ]);
+
+        $config = file_get_contents(storage_path('app/vhosts/laratest.dev.conf'));
+        $this->assertStringContainsString('index index.php index.html index.htm;', $config);
+        $this->assertStringContainsString('try_files $uri $uri/ /index.php?query_string', $config);
+
+        return $site;
+    }
+
+    /**
+     * @test
+     * @depends laravel_projects_use_php_nginx_config
+     */
+    public function disabling_project_removes_nginx_symlink(Site $site): void
+    {
+        $site->update(['is_enabled' => false]);
+
+        $this->assertFileNotExists('/etc/nginx/sites-enabled/laratest.dev.conf');
+
+        unlink(storage_path('app/vhosts/laratest.dev.conf'));
+        exec('rm -rf "' . $site->document_root . '"');
+    }
+
+    /** @test */
+    public function pull_creates_project_root_if_it_does_not_exist(): void
+    {
+        $path = resource_path('test-skel/noexisty');
+        $site = Site::create([
+            'name' => 'pull sans root',
+        ]);
+
+        $this->assertDirectoryNotExists($path);
+        $site->document_root = $path;
+        $site->update([
+            'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
+            'source_branch' => 'develop',
+
+            'name' => 'pull-sans-root',
+            'type' => 'php',
+        ]);
+
+        $this->assertDirectoryExists($path);
+        exec('rm -rf "' . $path . '"');
+    }
+}

--- a/tests/Unit/SiteTest.php
+++ b/tests/Unit/SiteTest.php
@@ -10,6 +10,47 @@ class SiteTest extends TestCase
 {
     use RefreshDatabase;
 
+    public const PHP_LOG_PATH = '/var/log/php%d.%d-fpm.log';
+
+    /** @test */
+    public function logs_include_only_php_log_for_php_projects(): void
+    {
+        $site = Site::create(['name' => 'loggable', 'type' => 'php']);
+
+        $logs = $site->logs;
+        $logPath = ini_get('error_log')
+            ?: sprintf(self::PHP_LOG_PATH, PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+
+        $this->assertCount(1, $logs);
+        $this->assertArrayHasKey('php', $logs);
+        $this->assertEquals($logPath, $logs['php']['path']);
+    }
+
+    /** @test */
+    public function logs_include_php_and_laravel_logs_for_laravel_projects(): void
+    {
+        $site = Site::create(['name' => 'loggable', 'type' => 'laravel']);
+
+        $logs = $site->logs;
+        $logPath = ini_get('error_log')
+            ?: sprintf(self::PHP_LOG_PATH, PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+
+        $this->assertCount(2, $logs);
+        $this->assertArrayHasKey('php', $logs);
+        $this->assertArrayHasKey('laravel', $logs);
+        $this->assertEquals($logPath, $logs['php']['path']);
+        $this->assertEquals('storage/logs/laravel.log', $logs['laravel']['path']);
+    }
+
+    /** @test */
+    public function logs_is_empty_for_non_php_or_laravel_projects(): void
+    {
+        $site = Site::create(['name' => 'loggable', 'type' => 'basic']);
+
+        $logs = $site->logs;
+        $this->assertEmpty($logs);
+    }
+
     /** @test */
     public function system_user_is_null_when_not_found(): void
     {

--- a/tests/Unit/SiteTest.php
+++ b/tests/Unit/SiteTest.php
@@ -52,6 +52,20 @@ class SiteTest extends TestCase
     }
 
     /** @test */
+    public function readLog_prefixes_relative_paths_with_docroot(): void
+    {
+        $root = resource_path('test-skel/logrel');
+        $path = $root . '/storage/logs/laravel.log';
+        $site = new Site([
+            'name' => 'logrel',
+            'type' => 'laravel',
+            'document_root' => $root,
+        ]);
+
+        $this->assertEquals('It works!', $site->readLog('laravel'));
+    }
+
+    /** @test */
     public function system_user_is_null_when_not_found(): void
     {
         $site = Site::create(['name' => 'ghosty']);

--- a/tests/Unit/SiteTest.php
+++ b/tests/Unit/SiteTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Servidor\Site;
+use Tests\TestCase;
+
+class SiteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function system_user_is_null_when_not_found(): void
+    {
+        $site = Site::create(['name' => 'ghosty']);
+        $site->system_user = 2342;
+
+        $this->assertEquals('ghosty', $site->name);
+        $this->assertNull($site->systemUser);
+    }
+}


### PR DESCRIPTION
Adds related logs to a site's overview page. Each log is fetched using `cat` through sudo to avoid permissions issues with logs owned by the root user when trying to open them in the file viewer.