### PR TITLE
Separate the public folder into its own field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * An install script! Installation is now the same across dev *and* "prod"
+* Public folder can be defined separately from docroot for Laravel projects
 
 ### Changed
 * Project folder paths will fall back to site name when domain isn't set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * An install script! Installation is now the same across dev *and* "prod"
 
 ### Changed
-* Project folder paths will now fall back to site name when domain isn't set
+* Project folder paths will fall back to site name when domain isn't set
 
 ### Fixed
 * Nginx sites no longer try to use the old PHP 7.3 socket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Nginx sites no longer try to use the old PHP 7.3 socket
+* Overflowing dropdowns in site editor don't overflow past the grid any more
 
 
 ## [0.9.0] - 2020-08-11

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -57,7 +57,7 @@ class SiteController extends Controller
      */
     public function pull(Site $site): JsonResponse
     {
-        $root = $site->document_root;
+        $root = $site->project_root;
         $branch = $site->source_branch;
 
         if (!$site->type || 'redirect' == $site->type) {

--- a/app/Http/Requests/UpdateSite.php
+++ b/app/Http/Requests/UpdateSite.php
@@ -39,6 +39,7 @@ class UpdateSite extends FormRequest
             'source_repo' => 'required_unless:type,redirect|nullable|url',
             'source_branch' => 'nullable|string',
             'project_root' => 'required_unless:type,redirect|nullable|string',
+            'public_dir' => 'required_if:type,laravel|nullable|string',
             'redirect_type' => 'required_if:type,redirect|nullable|integer',
             'redirect_to' => 'required_if:type,redirect|nullable|string',
             'is_enabled' => 'boolean',

--- a/app/Http/Requests/UpdateSite.php
+++ b/app/Http/Requests/UpdateSite.php
@@ -38,7 +38,7 @@ class UpdateSite extends FormRequest
             'type' => 'required|in:basic,php,laravel,redirect',
             'source_repo' => 'required_unless:type,redirect|nullable|url',
             'source_branch' => 'nullable|string',
-            'document_root' => 'required_unless:type,redirect|nullable|string',
+            'project_root' => 'required_unless:type,redirect|nullable|string',
             'redirect_type' => 'required_if:type,redirect|nullable|integer',
             'redirect_to' => 'required_if:type,redirect|nullable|string',
             'is_enabled' => 'boolean',

--- a/app/Listeners/WriteSiteConfig.php
+++ b/app/Listeners/WriteSiteConfig.php
@@ -75,7 +75,7 @@ class WriteSiteConfig
 
     private function pullSite(): void
     {
-        $root = $this->site->document_root;
+        $root = $this->site->project_root;
         $branch = $this->site->source_branch;
 
         if (!$this->site->type || 'redirect' == $this->site->type || !$root) {

--- a/app/Site.php
+++ b/app/Site.php
@@ -27,10 +27,22 @@ class Site extends Model
         'source_repo',
         'source_branch',
         'project_root',
+        'public_dir',
         'redirect_type',
         'redirect_to',
         'is_enabled',
     ];
+
+    public function getDocumentRootAttribute(): string
+    {
+        $docroot = $this->project_root;
+
+        if ('laravel' === $this->type) {
+            $docroot .= $this->public_dir;
+        }
+
+        return $docroot;
+    }
 
     public function getLogsAttribute(): array
     {
@@ -50,9 +62,11 @@ class Site extends Model
 
     public function readLog(string $log): string
     {
-        $path = Str::startsWith($this->logs[$log]['path'], '/') ? '' : (
-            Str::beforeLast($this->project_root, '/public') . '/'
-        ) . $this->logs[$log]['path'];
+        $path = $this->logs[$log]['path'];
+
+        if (!Str::startsWith($path, '/')) {
+            $path = $this->project_root . '/' . $path;
+        }
 
         exec('sudo cat ' . escapeshellarg($path), $file);
 

--- a/app/Site.php
+++ b/app/Site.php
@@ -26,7 +26,7 @@ class Site extends Model
         'type',
         'source_repo',
         'source_branch',
-        'document_root',
+        'project_root',
         'redirect_type',
         'redirect_to',
         'is_enabled',
@@ -51,7 +51,7 @@ class Site extends Model
     public function readLog(string $log): string
     {
         $path = Str::startsWith($this->logs[$log]['path'], '/') ? '' : (
-            Str::beforeLast($this->document_root, '/public') . '/'
+            Str::beforeLast($this->project_root, '/public') . '/'
         ) . $this->logs[$log]['path'];
 
         exec('sudo cat ' . escapeshellarg($path), $file);

--- a/database/migrations/2020_09_19_211510_change_docroot_to_project_root_in_sites_table.php
+++ b/database/migrations/2020_09_19_211510_change_docroot_to_project_root_in_sites_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeDocrootToProjectRootInSitesTable extends Migration
+{
+    public function __construct()
+    {
+        // This is required because the change operations in this
+        // migration will otherwise fail with an exception caused
+        // by the lack of an enum type in DBAL's MySQLPlatform.
+        //
+        // Future migrations with changes should work without
+        // issue as long as this snippet is kept in-tact.
+        Schema::getConnection()->getDoctrineSchemaManager()
+                               ->getDatabasePlatform()
+                               ->registerDoctrineTypeMapping('enum', 'string');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sites', function (Blueprint $table): void {
+            $table->renameColumn('document_root', 'project_root');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sites', function (Blueprint $table): void {
+            $table->renameColumn('project_root', 'document_root');
+        });
+    }
+}

--- a/database/migrations/2020_09_19_213602_add_public_dir_column_to_sites_table.php
+++ b/database/migrations/2020_09_19_213602_add_public_dir_column_to_sites_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPublicDirColumnToSitesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sites', function (Blueprint $table): void {
+            $table->string('public_dir')->nullable()->after('project_root');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sites', function (Blueprint $table): void {
+            $table->dropColumn('public_dir');
+        });
+    }
+}

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -92,11 +92,11 @@
             </sui-form-fields>
 
             <sui-form-field v-if="['basic', 'php', 'laravel'].includes(tmpSite.type)"
-                :error="'document_root' in errors">
+                :error="'project_root' in errors">
                 <label>Document Root</label>
-                <sui-input readonly v-model="tmpSite.document_root" />
-                <sui-label basic color="red" pointing v-if="'document_root' in errors">
-                    {{ errors.document_root[0] }}
+                <sui-input readonly v-model="tmpSite.project_root" />
+                <sui-label basic color="red" pointing v-if="'project_root' in errors">
+                    {{ errors.project_root[0] }}
                 </sui-label>
             </sui-form-field>
 
@@ -199,7 +199,7 @@ export default {
                 }
             }
 
-            site.document_root = val;
+            site.project_root = val;
         },
     },
 };

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -91,7 +91,7 @@
                 </sui-form-field>
             </sui-form-fields>
 
-            <sui-form-field v-if="['basic', 'php', 'laravel'].includes(tmpSite.type)"
+            <sui-form-field v-if="['basic', 'php'].includes(tmpSite.type)"
                 :error="'project_root' in errors">
                 <label>Document Root</label>
                 <sui-input readonly v-model="tmpSite.project_root" />
@@ -99,6 +99,24 @@
                     {{ errors.project_root[0] }}
                 </sui-label>
             </sui-form-field>
+
+            <sui-form-fields v-else-if="tmpSite.type == 'laravel'">
+                <sui-form-field :width="12" :error="'project_root' in errors">
+                    <label>Document Root</label>
+                    <sui-input v-model="tmpSite.project_root" />
+                    <sui-label basic color="red" pointing v-if="'project_root' in errors">
+                        {{ errors.project_root[0] }}
+                    </sui-label>
+                </sui-form-field>
+
+                <sui-form-field :width="4" :error="'public_dir' in errors">
+                    <label>Public Folder</label>
+                    <sui-input v-model="tmpSite.public_dir" />
+                    <sui-label basic color="red" pointing v-if="'public_dir' in errors">
+                        {{ errors.public_dir[0] }}
+                    </sui-label>
+                </sui-form-field>
+            </sui-form-fields>
 
             <sui-header content="System User" />
             <sui-segment :inverted="darkMode" v-if="!tmpSite.system_user">
@@ -189,17 +207,15 @@ export default {
         },
         setDocroot() {
             const site = this.tmpSite;
-            let val = '';
+            let dir = '', root = '';
 
             if (['basic', 'php', 'laravel'].includes(site.type)) {
-                val = `/var/www/${site.primary_domain || _.kebabCase(site.name)}`;
-
-                if ('laravel' === site.type) {
-                    val += '/public';
-                }
+                dir = 'laravel' === site.type ? '/public' : '/';
+                root = `/var/www/${site.primary_domain || _.kebabCase(site.name)}`;
             }
 
-            site.project_root = val;
+            site.project_root = root;
+            site.public_dir = dir;
         },
     },
 };

--- a/resources/js/components/Sites/Editor.vue
+++ b/resources/js/components/Sites/Editor.vue
@@ -24,7 +24,7 @@
 
             <sui-header content="Primary Domain" />
             <sui-form-fields>
-                <sui-form-field :width="12" :error="'primary_domain' in errors">
+                <sui-form-field :width="11" :error="'primary_domain' in errors">
                     <label>Domain Name</label>
                     <sui-input placeholder="example.com" @input="setDocroot"
                         v-model="tmpSite.primary_domain" />
@@ -33,7 +33,7 @@
                             {{ errors.primary_domain[0] }}
                         </sui-label>
                 </sui-form-field>
-                <sui-form-field :width="4" :error="'type' in errors">
+                <sui-form-field :width="5" :error="'type' in errors">
                     <label>Project type</label>
                     <sui-dropdown selection :options="[
                         { text: 'Redirect', value: 'redirect' },
@@ -72,7 +72,7 @@
             </sui-form-fields>
 
             <sui-form-fields v-if="tmpSite.type && tmpSite.type != 'redirect'">
-                <sui-form-field :width="12" :error="'source_repo' in errors">
+                <sui-form-field :width="11" :error="'source_repo' in errors">
                     <label>Clone URL</label>
                     <sui-input v-model="tmpSite.source_repo"
                         @change="refreshBranches(tmpSite.source_repo)" />
@@ -80,7 +80,7 @@
                         {{ errors.source_repo[0] }}
                     </sui-label>
                 </sui-form-field>
-                <sui-form-field :width="4" :error="'source_branch' in errors">
+                <sui-form-field :width="5" :error="'source_branch' in errors">
                     <label>Branch</label>
                     <sui-dropdown search selection :loading="loadingBranches"
                         :options="branches" v-model="tmpSite.source_branch"
@@ -101,7 +101,7 @@
             </sui-form-field>
 
             <sui-form-fields v-else-if="tmpSite.type == 'laravel'">
-                <sui-form-field :width="12" :error="'project_root' in errors">
+                <sui-form-field :width="11" :error="'project_root' in errors">
                     <label>Document Root</label>
                     <sui-input v-model="tmpSite.project_root" />
                     <sui-label basic color="red" pointing v-if="'project_root' in errors">
@@ -109,7 +109,7 @@
                     </sui-label>
                 </sui-form-field>
 
-                <sui-form-field :width="4" :error="'public_dir' in errors">
+                <sui-form-field :width="5" :error="'public_dir' in errors">
                     <label>Public Folder</label>
                     <sui-input v-model="tmpSite.public_dir" />
                     <sui-label basic color="red" pointing v-if="'public_dir' in errors">

--- a/resources/js/components/Sites/SiteItem.vue
+++ b/resources/js/components/Sites/SiteItem.vue
@@ -7,8 +7,8 @@
         </sui-card-content>
 
         <sui-card-content extra>
-            <router-link :to="{ name: 'files', params: { path: site.document_root } }"
-                slot="right" v-if="site.document_root != null">
+            <router-link :to="{ name: 'files', params: { path: site.project_root } }"
+                slot="right" v-if="site.project_root != null">
                 <sui-icon name="open folder" /> Browse Files
             </router-link>
         </sui-card-content>

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -46,14 +46,14 @@
                     </sui-grid-row>
                 </sui-grid>
 
-                <sui-header size="tiny" :inverted="darkMode" v-if="site.document_root">
-                    <router-link :to="{ name: 'files', params: {path: site.document_root } }"
+                <sui-header size="tiny" :inverted="darkMode" v-if="site.project_root">
+                    <router-link :to="{ name: 'files', params: {path: site.project_root } }"
                                  content="Browse files" is="sui-button" floated="right"
                                  basic primary icon="open folder" />
-                    Document Root
-                    <sui-header-subheader>{{ site.document_root }}</sui-header-subheader>
+                    Project Root
+                    <sui-header-subheader>{{ site.project_root }}</sui-header-subheader>
                 </sui-header>
-                <p v-else>This project doesn't have a document root defined.</p>
+                <p v-else>This project doesn't have a project root defined.</p>
             </sui-segment>
 
             <sui-header v-if="site.type == 'redirect'" attached="top" :inverted="darkMode">

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -175,7 +175,7 @@ export default {
             return state.sites.find(s => s.id === id);
         },
         findByDocroot: state => path => {
-            return state.sites.find(s => s.document_root === path);
+            return state.sites.find(s => s.project_root === path);
         },
         branchOptions: state => {
             return state.branches.map(b => {

--- a/resources/views/sites/server-templates/php.blade.php
+++ b/resources/views/sites/server-templates/php.blade.php
@@ -1,7 +1,7 @@
 server {
     server_name {{ $site->primary_domain }};
 
-    root {{ $site->document_root }};
+    root {{ $site->project_root }};
     index index.php index.html index.htm;
 
     location / {

--- a/resources/views/sites/server-templates/php.blade.php
+++ b/resources/views/sites/server-templates/php.blade.php
@@ -1,7 +1,7 @@
 server {
     server_name {{ $site->primary_domain }};
 
-    root {{ $site->project_root }};
+    root {{ $site->document_root }};
     index index.php index.html index.htm;
 
     location / {

--- a/tests/Feature/Api/SitesTest.php
+++ b/tests/Feature/Api/SitesTest.php
@@ -153,7 +153,7 @@ class SitesTest extends TestCase
             'name' => 'My Updated Blog',
             'type' => 'basic',
             'source_repo' => 'https://github.com/user/blog.git',
-            'document_root' => '/var/www/blog',
+            'project_root' => '/var/www/blog',
         ]);
 
         $updated = Site::findOrFail($site->id);
@@ -162,7 +162,7 @@ class SitesTest extends TestCase
         $this->assertEquals('My Blog', $updated->name);
         $this->assertNull($updated->type);
         $this->assertNull($updated->source_repo);
-        $this->assertNull($updated->document_root);
+        $this->assertNull($updated->project_root);
     }
 
     /** @test */
@@ -174,7 +174,7 @@ class SitesTest extends TestCase
             'name' => 'My Updated Blog',
             'type' => 'basic',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
-            'document_root' => '/var/www/blog',
+            'project_root' => '/var/www/blog',
             'primary_domain' => 'test.com',
         ]);
 
@@ -184,7 +184,7 @@ class SitesTest extends TestCase
         $this->assertEquals('My Updated Blog', $updated->name);
         $this->assertEquals('basic', $updated->type);
         $this->assertEquals('https://github.com/dshoreman/servidor-test-site.git', $updated->source_repo);
-        $this->assertEquals('/var/www/blog', $updated->document_root);
+        $this->assertEquals('/var/www/blog', $updated->project_root);
     }
 
     /** @test */
@@ -208,7 +208,7 @@ class SitesTest extends TestCase
         $response = $this->authed()->putJson('/api/sites/' . $site->id, [
             'create_user' => true,
             'name' => 'Hello World',
-            'document_root' => '/var/www/hello-world',
+            'project_root' => '/var/www/hello-world',
             'primary_domain' => 'example.com',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'type' => 'basic',
@@ -254,7 +254,7 @@ class SitesTest extends TestCase
         $site = Site::create([
             'name' => 'Dummy Site',
             'type' => 'basic',
-            'document_root' => $dir,
+            'project_root' => $dir,
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
         ]);
 
@@ -263,7 +263,7 @@ class SitesTest extends TestCase
         $response->assertOk();
         $this->assertDirectoryExists($dir . '/.git');
 
-        exec('rm -rf "' . $site->document_root . '"');
+        exec('rm -rf "' . $site->project_root . '"');
     }
 
     /** @test */
@@ -282,7 +282,7 @@ class SitesTest extends TestCase
     }
 
     /** @test */
-    public function cannot_pull_site_when_missing_document_root(): void
+    public function cannot_pull_site_when_missing_project_root(): void
     {
         $site = Site::create([
             'name' => 'Dummy Site',
@@ -304,7 +304,7 @@ class SitesTest extends TestCase
         $site = Site::create([
             'name' => 'Site for checkout',
             'type' => 'basic',
-            'document_root' => $dir,
+            'project_root' => $dir,
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
         ]);
         $site->update(['is_enabled' => true]);
@@ -314,7 +314,7 @@ class SitesTest extends TestCase
         $response->assertOk();
         $response->assertJsonFragment([
             'name' => 'Site for checkout',
-            'document_root' => $dir,
+            'project_root' => $dir,
             'is_enabled' => true,
         ]);
 
@@ -328,7 +328,7 @@ class SitesTest extends TestCase
         $site = Site::create([
             'type' => 'basic',
             'name' => 'Creating Docroot',
-            'document_root' => $dir,
+            'project_root' => $dir,
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
         ]);
 
@@ -338,7 +338,7 @@ class SitesTest extends TestCase
         $response->assertOk();
         $response->assertJsonFragment([
             'name' => 'Creating Docroot',
-            'document_root' => $dir,
+            'project_root' => $dir,
             'type' => 'basic',
         ]);
         $this->assertDirectoryExists($dir);

--- a/tests/Unit/Http/Requests/UpdateSiteRequestTest.php
+++ b/tests/Unit/Http/Requests/UpdateSiteRequestTest.php
@@ -86,7 +86,7 @@ class UpdateSiteRequestTest extends TestCase
         $dataWithout = [
             'name' => 'Test Site',
             'primary_domain' => 'example-without.com',
-            'document_root' => '/',
+            'project_root' => '/',
         ];
         $dataWith = array_merge($dataWithout, [
             'source_repo' => 'https://github.com/foo/bar.git',
@@ -134,27 +134,27 @@ class UpdateSiteRequestTest extends TestCase
     }
 
     /** @test */
-    public function site_document_root_is_required_when_type_is_not_redirect(): void
+    public function site_project_root_is_required_when_type_is_not_redirect(): void
     {
         $v = $this->getValidator(['type' => 'php']);
 
-        $this->assertStringContainsString('required', $v->errors()->first('document_root'));
+        $this->assertStringContainsString('required', $v->errors()->first('project_root'));
         $this->assertFalse($v->passes());
 
         $v = $this->getValidator([
             'name' => 'foo',
             'primary_domain' => 'localhost',
             'type' => 'php',
-            'document_root' => '/',
+            'project_root' => '/',
             'source_repo' => 'https://github.com/foo/bar.git',
         ]);
 
-        $this->assertEmpty($v->errors()->get('document_root'));
+        $this->assertEmpty($v->errors()->get('project_root'));
         $this->assertTrue($v->passes());
     }
 
     /** @test */
-    public function site_document_root_is_not_required_when_type_is_redirect(): void
+    public function site_project_root_is_not_required_when_type_is_redirect(): void
     {
         $data = [
             'name' => 'Test Site',
@@ -166,18 +166,18 @@ class UpdateSiteRequestTest extends TestCase
 
         $v = $this->getValidator($data);
 
-        $this->assertEmpty($v->errors()->get('document_root'));
+        $this->assertEmpty($v->errors()->get('project_root'));
         $this->assertTrue($v->passes());
     }
 
     /** @test */
-    public function site_document_root_must_be_a_string(): void
+    public function site_project_root_must_be_a_string(): void
     {
-        $this->assertTrue($this->validateField('document_root', '/'));
-        $this->assertFalse($this->validateField('document_root', 42));
-        $this->assertFalse($this->validateField('document_root', true));
-        $this->assertFalse($this->validateField('document_root', ['a', 'b']));
-        $this->assertFalse($this->validateField('document_root', (object) ['a', 'b']));
+        $this->assertTrue($this->validateField('project_root', '/'));
+        $this->assertFalse($this->validateField('project_root', 42));
+        $this->assertFalse($this->validateField('project_root', true));
+        $this->assertFalse($this->validateField('project_root', ['a', 'b']));
+        $this->assertFalse($this->validateField('project_root', (object) ['a', 'b']));
     }
 
     /** @test */

--- a/tests/Unit/Listeners/WriteSiteConfigTest.php
+++ b/tests/Unit/Listeners/WriteSiteConfigTest.php
@@ -22,7 +22,7 @@ class WriteSiteConfigTest extends TestCase
             'name' => 'symlinkery',
         ]);
         $site->update([
-            'document_root' => $path,
+            'project_root' => $path,
             'primary_domain' => 'symlinkery.dev',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'source_branch' => 'develop',
@@ -34,7 +34,7 @@ class WriteSiteConfigTest extends TestCase
         $this->assertFileExists($link);
         $this->assertEquals($target, readlink($link));
 
-        exec("rm -rf \"{$site->document_root}\"; sudo rm \"{$link}\"");
+        exec("rm -rf \"{$site->project_root}\"; sudo rm \"{$link}\"");
     }
 
     /** @test */
@@ -45,7 +45,7 @@ class WriteSiteConfigTest extends TestCase
         $site = Site::create(['name' => 'symlinkeroo']);
 
         $site->update([
-            'document_root' => $path,
+            'project_root' => $path,
             'primary_domain' => 'symlinkeroo.dev',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'source_branch' => 'develop',
@@ -59,7 +59,7 @@ class WriteSiteConfigTest extends TestCase
         $this->assertEquals('symlinkeroo-updated', $site->name);
         $this->assertSame($linkBefore, readlink($link));
 
-        exec("rm -rf \"{$site->document_root}\"; sudo rm \"{$link}\"");
+        exec("rm -rf \"{$site->project_root}\"; sudo rm \"{$link}\"");
     }
 
     /** @test */
@@ -70,7 +70,7 @@ class WriteSiteConfigTest extends TestCase
         $path = resource_path('test-skel/outdated-project');
         $site = Site::create(['name' => 'linkoutdated']);
 
-        $site->document_root = $path;
+        $site->project_root = $path;
         $site->update([
             'primary_domain' => 'outdated.dev',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
@@ -88,7 +88,7 @@ class WriteSiteConfigTest extends TestCase
         $this->assertTrue(is_link($link));
         $this->assertEquals($vhost, readlink($link));
 
-        exec("rm -rf \"{$site->document_root}\"; sudo rm \"{$link}\"");
+        exec("rm -rf \"{$site->project_root}\"; sudo rm \"{$link}\"");
     }
 
     /** @test */
@@ -97,7 +97,7 @@ class WriteSiteConfigTest extends TestCase
         $path = resource_path('test-skel/foo');
         $site = Site::create(['name' => 'Untitled']);
 
-        $site->document_root = $path;
+        $site->project_root = $path;
         $site->update([
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'primary_domain' => 'basicdefault.example',
@@ -113,7 +113,7 @@ class WriteSiteConfigTest extends TestCase
     {
         $site = Site::create(['name' => 'laratest']);
 
-        $site->document_root = resource_path('test-skel/larafoo');
+        $site->project_root = resource_path('test-skel/larafoo');
         $site->update([
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'primary_domain' => 'laratest.dev',
@@ -140,7 +140,7 @@ class WriteSiteConfigTest extends TestCase
         $this->assertFileNotExists('/etc/nginx/sites-enabled/laratest.dev.conf');
 
         unlink(storage_path('app/vhosts/laratest.dev.conf'));
-        exec('rm -rf "' . $site->document_root . '"');
+        exec('rm -rf "' . $site->project_root . '"');
     }
 
     /** @test */
@@ -152,7 +152,7 @@ class WriteSiteConfigTest extends TestCase
         ]);
 
         $this->assertDirectoryNotExists($path);
-        $site->document_root = $path;
+        $site->project_root = $path;
         $site->update([
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'source_branch' => 'develop',
@@ -172,7 +172,7 @@ class WriteSiteConfigTest extends TestCase
         $site = Site::create(['name' => 'rootperms']);
 
         $this->assertDirectoryNotExists($path);
-        $site->document_root = $path;
+        $site->project_root = $path;
         $site->update([
             'primary_domain' => 'rootperms.example',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',

--- a/tests/Unit/Listeners/WriteSiteConfigTest.php
+++ b/tests/Unit/Listeners/WriteSiteConfigTest.php
@@ -168,7 +168,7 @@ class WriteSiteConfigTest extends TestCase
     /** @test */
     public function pull_creates_root_with_correct_permissions(): void
     {
-        $path = '/var/www/rootperms.example/public';
+        $path = '/var/www/rootperms.example';
         $site = Site::create(['name' => 'rootperms']);
 
         $this->assertDirectoryNotExists($path);
@@ -177,6 +177,7 @@ class WriteSiteConfigTest extends TestCase
             'primary_domain' => 'rootperms.example',
             'source_repo' => 'https://github.com/dshoreman/servidor-test-site.git',
             'source_branch' => 'develop',
+            'public_dir' => '/public',
             'type' => 'laravel',
         ]);
 

--- a/tests/Unit/SiteTest.php
+++ b/tests/Unit/SiteTest.php
@@ -59,7 +59,7 @@ class SiteTest extends TestCase
         $site = new Site([
             'name' => 'logrel',
             'type' => 'laravel',
-            'document_root' => $root,
+            'project_root' => $root,
         ]);
 
         $this->assertEquals('It works!', $site->readLog('laravel'));

--- a/tests/Unit/SiteTest.php
+++ b/tests/Unit/SiteTest.php
@@ -13,6 +13,27 @@ class SiteTest extends TestCase
     public const PHP_LOG_PATH = '/var/log/php%d.%d-fpm.log';
 
     /** @test */
+    public function document_root_matches_project_root_in_non_laravel_projects(): void
+    {
+        $site = Site::create(['name' => 'rootcheck', 'type' => 'basic']);
+        $site->project_root = '/var/www/rootcheck';
+        $site->public_dir = '/';
+
+        $this->assertEquals('/var/www/rootcheck', $site->document_root);
+    }
+
+    /** @test */
+    public function document_root_includes_public_dir_in_laravel_projects(): void
+    {
+        $site = Site::create(['name' => 'lararoot', 'type' => 'laravel']);
+
+        $site->project_root = '/var/www/lararoot';
+        $site->public_dir = '/public';
+
+        $this->assertEquals('/var/www/lararoot/public', $site->document_root);
+    }
+
+    /** @test */
     public function logs_include_only_php_log_for_php_projects(): void
     {
         $site = Site::create(['name' => 'loggable', 'type' => 'php']);
@@ -60,6 +81,7 @@ class SiteTest extends TestCase
             'name' => 'logrel',
             'type' => 'laravel',
             'project_root' => $root,
+            'public_dir' => '/public',
         ]);
 
         $this->assertEquals('It works!', $site->readLog('laravel'));


### PR DESCRIPTION
This renames the `document_root` field to `project_root` to signify that it's not necessarily going to be the actual `root` used in its nginx server block. Instead, `document_root` is now an attribute getter that combines `project_root` with a new `public_dir` attribute. This should make it a lot easier to deal with cloning laravel or similar projects.
