### PR TITLE
Update dependencies and eslint rules

### DIFF
--- a/build/eslint/config.json
+++ b/build/eslint/config.json
@@ -116,7 +116,7 @@
         "strict": "error",
 
         /* Variables */
-        "init-declarations": "off",
+        "init-declarations": [ "error", "always" ],
         "no-label-var": "error",
         "no-restricted-globals": "error",
         "no-shadow": "error",
@@ -188,6 +188,7 @@
         "max-statements": "error",
         "max-statements-per-line": "error",
         "multiline-comment-style": [ "error", "separate-lines" ],
+        "multiline-ternary": [ "error", "always-multiline" ],
         "new-cap": "error",
         "new-parens": "error",
         "newline-per-chained-call": ["error", {
@@ -236,7 +237,7 @@
             { "blankLine": "any",    "prev": ["const", "let", "var"], "next": ["const", "let", "var"]}
         ],
         "prefer-exponentiation-operator": "error",
-        "prefer-object-spread": "off",
+        "prefer-object-spread": "error",
         "quote-props": ["error", "as-needed"],
         "quotes": [ "error", "single", {
             "avoidEscape": true
@@ -282,7 +283,10 @@
         }],
         "prefer-arrow-callback": "error",
         "prefer-const": "error",
-        "prefer-destructuring": "off",
+        "prefer-destructuring": [ "error", {
+          "array": true,
+          "object": true
+        }],
         "prefer-numeric-literals": "error",
         "prefer-rest-params": "error",
         "prefer-spread": "error",

--- a/build/eslint/config.json
+++ b/build/eslint/config.json
@@ -2,7 +2,7 @@
     "env": {
         "browser": true,
         "commonjs": true,
-        "es6": true
+        "es2020": true
     },
     "extends": [
         "eslint:recommended",
@@ -15,9 +15,6 @@
         "Vue": "readonly",
         "_": "readonly"
     },
-    "parserOptions": {
-        "ecmaVersion": 2018
-    },
     "plugins": [
         "vue"
     ],
@@ -26,11 +23,12 @@
         /* Possible errors */
         "no-await-in-loop": "error",
         "no-console": "error",
-        "no-dupe-else-if": "error",
         "no-extra-parens": "error",
-        "no-import-assign": "error",
-        "no-setter-return": "error",
+        "no-loss-of-precision": "error",
+        "no-promise-executor-return": "error",
         "no-template-curly-in-string": "error",
+        "no-unreachable-loop": "error",
+        "no-useless-backreference": "error",
         "require-atomic-updates": "error",
 
         /* Best practices */
@@ -42,6 +40,7 @@
         "consistent-return": "error",
         "curly": "error",
         "default-case": "error",
+        "default-case-last": "error",
         "default-param-last": "error",
         "dot-location": ["error", "property"],
         "dot-notation": "error",
@@ -124,22 +123,13 @@
         "no-undef-init": "error",
         "no-undefined": "error",
         "no-unused-vars": [ "error", {
-            "varsIgnorePattern": "app"
+            "args": "all",
+            "vars": "all",
+            "caughtErrors": "all",
+            "argsIgnorePattern": "^_|to|from$",
+            "varsIgnorePattern": "^app$"
         }],
         "no-use-before-define": "error",
-
-        /* Node/CommonJS */
-        "callback-return": "error",
-        "global-require": "error",
-        "handle-callback-err": "error",
-        "no-buffer-constructor": "error",
-        "no-mixed-requires": "error",
-        "no-new-require": "error",
-        "no-path-concat": "error",
-        "no-process-env": "error",
-        "no-process-exit": "error",
-        "no-restricted-modules": "error",
-        "no-sync": "error",
 
         /* Stylistic issues */
         "array-bracket-newline": [ "error", "consistent" ],
@@ -151,6 +141,9 @@
         "brace-style": [ "error", "1tbs" ],
         "capitalized-comments": [ "error", "always", {
             "ignoreConsecutiveComments": true
+        }],
+        "camelcase": [ "error", {
+            "properties": "never"
         }],
         "comma-dangle": ["error", "always-multiline"],
         "comma-spacing": [ "error", {
@@ -165,6 +158,7 @@
         "func-name-matching": "error",
         "func-names": [ "error", "as-needed" ],
         "func-style": "error",
+        "function-call-argument-newline": [ "error", "consistent" ],
         "function-paren-newline": [ "error", "consistent" ],
         "id-blacklist": "error",
         "id-length": "off",
@@ -277,6 +271,7 @@
         "generator-star-spacing": "error",
         "no-confusing-arrow": "error",
         "no-duplicate-imports": "error",
+        "no-restricted-exports": "error",
         "no-restricted-imports": "error",
         "no-useless-computed-key": "error",
         "no-useless-constructor": "error",

--- a/build/eslint/config.json
+++ b/build/eslint/config.json
@@ -263,7 +263,7 @@
         "wrap-regex": "error",
 
         /* ES6 aka ES2015 */
-        "arrow-body-style": "off",
+        "arrow-body-style": [ "error", "as-needed" ],
         "arrow-parens": [ "error", "as-needed" ],
         "arrow-spacing": [ "error", {
             "after": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,12 +3,12 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.8.3"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/compat-data": {
@@ -338,9 +338,9 @@
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.9.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-            "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
             "dev": true
         },
         "@babel/helper-wrap-function": {
@@ -367,12 +367,12 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-            "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.9.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
@@ -1205,6 +1205,76 @@
                 }
             }
         },
+        "@eslint/eslintrc": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+            "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "6.12.5",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+                    "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "debug": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
+                "espree": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+                    "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^7.4.0",
+                        "acorn-jsx": "^5.2.0",
+                        "eslint-visitor-keys": "^1.3.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1627,23 +1697,6 @@
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
             "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
             "dev": true
-        },
-        "ansi-escapes": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.11.0"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-                    "dev": true
-                }
-            }
         },
         "ansi-html": {
             "version": "0.0.7",
@@ -2478,12 +2531,6 @@
                 "supports-color": "^5.3.0"
             }
         },
-        "chardet": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-            "dev": true
-        },
         "charenc": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -2602,21 +2649,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true
-        },
-        "cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "^3.1.0"
-            }
-        },
-        "cli-width": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
             "dev": true
         },
         "cliui": {
@@ -3726,6 +3758,23 @@
                 }
             }
         },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            },
+            "dependencies": {
+                "ansi-colors": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+                    "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+                    "dev": true
+                }
+            }
+        },
         "entities": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
@@ -3850,22 +3899,24 @@
             "dev": true
         },
         "eslint": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-            "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
+            "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
+                "@eslint/eslintrc": "^0.1.3",
                 "ajv": "^6.10.0",
-                "chalk": "^2.1.0",
-                "cross-spawn": "^6.0.5",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^1.4.3",
-                "eslint-visitor-keys": "^1.1.0",
-                "espree": "^6.1.2",
-                "esquery": "^1.0.1",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^1.3.0",
+                "espree": "^7.3.0",
+                "esquery": "^1.2.0",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
                 "functional-red-black-tree": "^1.0.1",
@@ -3874,55 +3925,123 @@
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
-                "inquirer": "^7.0.0",
                 "is-glob": "^4.0.0",
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.14",
+                "levn": "^0.4.1",
+                "lodash": "^4.17.19",
                 "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.8.3",
+                "optionator": "^0.9.1",
                 "progress": "^2.0.0",
-                "regexpp": "^2.0.1",
-                "semver": "^6.1.2",
-                "strip-ansi": "^5.2.0",
-                "strip-json-comments": "^3.0.1",
+                "regexpp": "^3.1.0",
+                "semver": "^7.2.1",
+                "strip-ansi": "^6.0.0",
+                "strip-json-comments": "^3.1.0",
                 "table": "^5.2.3",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
+                "espree": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+                    "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^7.4.0",
+                        "acorn-jsx": "^5.2.0",
+                        "eslint-visitor-keys": "^1.3.0"
+                    }
+                },
+                "esrecurse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+                    "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+                    "dev": true,
+                    "requires": {
+                        "estraverse": "^5.2.0"
                     },
                     "dependencies": {
-                        "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                        "estraverse": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
                             "dev": true
                         }
                     }
                 },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -3930,34 +4049,28 @@
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 },
-                "path-key": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
                     "dev": true
                 },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "^1.0.0"
+                        "ansi-regex": "^5.0.0"
                     }
                 },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                    "dev": true
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
-                        "isexe": "^2.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -4002,9 +4115,9 @@
             }
         },
         "eslint-utils": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-            "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
@@ -4315,17 +4428,6 @@
                 "is-extendable": "^1.0.1"
             }
         },
-        "external-editor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-            "dev": true,
-            "requires": {
-                "chardet": "^0.7.0",
-                "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
-            }
-        },
         "extglob": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -4496,15 +4598,6 @@
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
             "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
             "dev": true
-        },
-        "figures": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "^1.0.5"
-            }
         },
         "file-entry-cache": {
             "version": "5.0.1",
@@ -6036,88 +6129,6 @@
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
-        "inquirer": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-            "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^3.0.0",
-                "cli-cursor": "^3.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^3.0.3",
-                "figures": "^3.0.0",
-                "lodash": "^4.17.15",
-                "mute-stream": "0.0.8",
-                "run-async": "^2.4.0",
-                "rxjs": "^6.5.3",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
         "internal-ip": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -6624,13 +6635,13 @@
             }
         },
         "levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
             }
         },
         "loader-runner": {
@@ -6905,12 +6916,6 @@
                 "mime-db": "1.44.0"
             }
         },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
-        },
         "minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7045,12 +7050,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-            "dev": true
-        },
-        "mute-stream": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "nan": {
@@ -7405,15 +7404,6 @@
                 "wrappy": "1"
             }
         },
-        "onetime": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-            "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^2.1.0"
-            }
-        },
         "opn": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -7434,17 +7424,17 @@
             }
         },
         "optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.3"
             }
         },
         "original": {
@@ -7460,12 +7450,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-            "dev": true
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
         "p-finally": {
@@ -8406,9 +8390,9 @@
             "dev": true
         },
         "prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
         },
         "prettier": {
@@ -8703,9 +8687,9 @@
             }
         },
         "regexpp": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
         },
         "regexpu-core": {
@@ -8926,16 +8910,6 @@
                 }
             }
         },
-        "restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "requires": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            }
-        },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -9003,12 +8977,6 @@
                 "inherits": "^2.0.1"
             }
         },
-        "run-async": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-            "dev": true
-        },
         "run-queue": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -9016,15 +8984,6 @@
             "dev": true,
             "requires": {
                 "aproba": "^1.1.1"
-            }
-        },
-        "rxjs": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-            "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -9887,9 +9846,9 @@
             "dev": true
         },
         "strip-json-comments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-            "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
         "style-loader": {
@@ -10173,15 +10132,6 @@
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
             "dev": true
         },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "~1.0.2"
-            }
-        },
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -10261,12 +10211,12 @@
             "dev": true
         },
         "type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "^1.2.1"
             }
         },
         "type-fest": {
@@ -10560,9 +10510,9 @@
             "dev": true
         },
         "v8-compile-cache": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-            "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
             "dev": true
         },
         "vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,6 +1237,12 @@
                 "@types/node": "*"
             }
         },
+        "@types/json-schema": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "dev": true
+        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1861,12 +1867,20 @@
             }
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+            "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
             "dev": true,
             "requires": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.10.0"
+            },
+            "dependencies": {
+                "follow-redirects": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+                    "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+                    "dev": true
+                }
             }
         },
         "babel-code-frame": {
@@ -1928,11 +1942,6 @@
                 }
             }
         },
-        "babel-helper-vue-jsx-merge-props": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz",
-            "integrity": "sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg=="
-        },
         "babel-loader": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -1964,15 +1973,6 @@
             "dev": true,
             "requires": {
                 "object.assign": "^4.1.0"
-            }
-        },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
             }
         },
         "balanced-match": {
@@ -2655,17 +2655,6 @@
                 }
             }
         },
-        "clone-deep": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-            "dev": true,
-            "requires": {
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.2",
-                "shallow-clone": "^3.0.0"
-            }
-        },
         "coa": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -2911,11 +2900,6 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
-        "core-js": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        },
         "core-js-compat": {
             "version": "3.6.5",
             "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -3016,18 +3000,18 @@
             }
         },
         "cross-env": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
-            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+            "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^7.0.0"
+                "cross-spawn": "^7.0.1"
             }
         },
         "cross-spawn": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-            "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
             "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
@@ -3979,20 +3963,30 @@
             }
         },
         "eslint-plugin-vue": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
-            "integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+            "version": "7.0.0-beta.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.0.0-beta.4.tgz",
+            "integrity": "sha512-yb8Kki8b94a3A1sGum9TyVAkvPfKGPzWfZcXRmA2Tylt7TRi+b6mOtn1o6kM3NWatBs5gcGiCrH033DDPn0Msw==",
             "dev": true,
             "requires": {
+                "eslint-utils": "^2.1.0",
                 "natural-compare": "^1.4.0",
-                "semver": "^5.6.0",
-                "vue-eslint-parser": "^7.0.0"
+                "semver": "^7.3.2",
+                "vue-eslint-parser": "^7.1.0"
             },
             "dependencies": {
+                "eslint-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
                     "dev": true
                 }
             }
@@ -4304,9 +4298,9 @@
             },
             "dependencies": {
                 "type": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+                    "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
                     "dev": true
                 }
             }
@@ -6552,6 +6546,12 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
+        "klona": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+            "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
+            "dev": true
+        },
         "laravel-mix": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-5.0.5.tgz",
@@ -6674,7 +6674,8 @@
         "lodash": {
             "version": "4.17.20",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "dev": true
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -8666,11 +8667,6 @@
                 "regenerate": "^1.4.0"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        },
         "regenerator-transform": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
@@ -8859,38 +8855,23 @@
             "dev": true
         },
         "resolve-url-loader": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.0.tgz",
-            "integrity": "sha512-2QcrA+2QgVqsMJ1Hn5NnJXIGCX1clQ1F6QJTqOeiaDw9ACo1G2k+8/shq3mtqne03HOFyskAClqfxKyFBriXZg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz",
+            "integrity": "sha512-K1N5xUjj7v0l2j/3Sgs5b8CjrrgtC70SmdCuZiJ8tSyb5J+uk3FoeZ4b7yTnH6j7ngI+Bc5bldHJIa8hYdu2gQ==",
             "dev": true,
             "requires": {
                 "adjust-sourcemap-loader": "2.0.0",
-                "camelcase": "5.0.0",
+                "camelcase": "5.3.1",
                 "compose-function": "3.0.3",
-                "convert-source-map": "1.6.0",
+                "convert-source-map": "1.7.0",
                 "es6-iterator": "2.0.3",
                 "loader-utils": "1.2.3",
-                "postcss": "7.0.14",
+                "postcss": "7.0.21",
                 "rework": "1.0.1",
                 "rework-visit": "1.0.0",
                 "source-map": "0.6.1"
             },
             "dependencies": {
-                "camelcase": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-                    "dev": true
-                },
-                "convert-source-map": {
-                    "version": "1.6.0",
-                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-                    "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.1"
-                    }
-                },
                 "emojis-list": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -8918,9 +8899,9 @@
                     }
                 },
                 "postcss": {
-                    "version": "7.0.14",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-                    "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+                    "version": "7.0.21",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+                    "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
                     "dev": true,
                     "requires": {
                         "chalk": "^2.4.2",
@@ -9077,16 +9058,70 @@
             }
         },
         "sass-loader": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-            "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.0.2.tgz",
+            "integrity": "sha512-wV6NDUVB8/iEYMalV/+139+vl2LaRFlZGEd5/xmdcdzQcgmis+npyco6NsDTVOlNA3y2NV9Gcz+vHyFMIT+ffg==",
             "dev": true,
             "requires": {
-                "clone-deep": "^4.0.1",
-                "loader-utils": "^1.2.3",
-                "neo-async": "^2.6.1",
-                "schema-utils": "^2.6.1",
-                "semver": "^6.3.0"
+                "klona": "^2.0.3",
+                "loader-utils": "^2.0.0",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^2.7.1",
+                "semver": "^7.3.2"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.5",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+                    "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+                    "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+                    "dev": true
+                },
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "neo-async": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+                    "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+                    "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.5",
+                        "ajv": "^6.12.4",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                }
             }
         },
         "sax": {
@@ -9127,14 +9162,9 @@
             "dev": true
         },
         "semantic-ui-vue": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/semantic-ui-vue/-/semantic-ui-vue-0.8.1.tgz",
-            "integrity": "sha512-ewur0XLCjTI/LBFHFzFQWx5Ke7MhsndpjojL3G9p+FtgUCjERKjO3+jKTXsfUL40IajZkzr04R1Hpz1QJ9YD+w==",
-            "requires": {
-                "babel-helper-vue-jsx-merge-props": "^2.0.2",
-                "babel-runtime": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/semantic-ui-vue/-/semantic-ui-vue-0.11.0.tgz",
+            "integrity": "sha512-wQE7zn7TIOPbLzbUp5hhIzivEkV6qk/i+Vc/BCQCQH7thF7UWqsEAcWWrlskwMTD48uoqGGUHIEN+kxsy0W3mA=="
         },
         "semver": {
             "version": "6.3.0",
@@ -9314,15 +9344,6 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "shallow-clone": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-            "dev": true,
-            "requires": {
-                "kind-of": "^6.0.2"
             }
         },
         "shebang-command": {
@@ -10578,26 +10599,26 @@
             }
         },
         "vue-eslint-parser": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",
-            "integrity": "sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz",
+            "integrity": "sha512-Kr21uPfthDc63nDl27AGQEhtt9VrZ9nkYk/NTftJ2ws9XiJwzJJCnCr3AITQ2jpRMA0XPGDECxYH8E027qMK9Q==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.1",
                 "eslint-scope": "^5.0.0",
                 "eslint-visitor-keys": "^1.1.0",
-                "espree": "^6.1.2",
+                "espree": "^6.2.1",
                 "esquery": "^1.0.1",
                 "lodash": "^4.17.15"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -10628,9 +10649,9 @@
             }
         },
         "vue-router": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.4.tgz",
-            "integrity": "sha512-qFfwwLvxUYq+iDJ0UoE8HMnuZEDtIDA+p573brVMb7NZr0t1vhMeMWDTvgF2b8MqAFOc77bNOTSSwYcR4pCZlg=="
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.5.tgz",
+            "integrity": "sha512-ioRY5QyDpXM9TDjOX6hX79gtaMXSVDDzSlbIlyAmbHNteIL81WIVB2e+jbzV23vzxtoV0krdS2XHm+GxFg+Nxg=="
         },
         "vue-style-loader": {
             "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -7,23 +7,23 @@
         "prod": "cross-env NODE_ENV=production webpack --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "axios": "^0.19.2",
-        "cross-env": "^6.0.3",
+        "axios": "^0.20.0",
+        "cross-env": "^7.0.2",
         "eslint": "^6.8.0",
-        "eslint-plugin-vue": "^6.2.2",
+        "eslint-plugin-vue": "^7.0.0-beta.4",
         "laravel-mix": "^5.0.5",
         "lodash": "^4.17.20",
-        "resolve-url-loader": "3.1.0",
+        "resolve-url-loader": "^3.1.1",
         "sass": "^1.26.11",
-        "sass-loader": "^8.0",
+        "sass-loader": "^10.0.2",
         "semantic-ui-sass": "^2.4.2",
         "vue": "^2.6.12",
         "vue-template-compiler": "^2.6.12"
     },
     "dependencies": {
-        "semantic-ui-vue": "^0.8.1",
+        "semantic-ui-vue": "^0.11.0",
         "vue-codemirror": "^4.0.6",
-        "vue-router": "^3.4.4",
+        "vue-router": "^3.4.5",
         "vuex": "^3.5.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "axios": "^0.20.0",
         "cross-env": "^7.0.2",
-        "eslint": "^6.8.0",
+        "eslint": "^7.10.0",
         "eslint-plugin-vue": "^7.0.0-beta.4",
         "laravel-mix": "^5.0.5",
         "lodash": "^4.17.20",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -47,9 +47,7 @@ router.beforeEach((to, from, next) => {
     next(nextpage);
 });
 
-window.axios.interceptors.response.use(response => {
-    return response;
-}, error => {
+window.axios.interceptors.response.use(response => response, error => {
     if (HTTP_UNAUTHORISED === error.response.status
         && 'invalid_credentials' !== error.response.data.error) {
         store.dispatch('forceLogin', 'Session timed out');

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,8 +30,8 @@ const router = new VueRouter({
 });
 
 router.beforeEach((to, from, next) => {
-    const token = store.getters.token;
-    let authed = store.getters.loggedIn, nextpage;
+    const nextpage = {}, { token } = store.getters;
+    let authed = store.getters.loggedIn;
 
     if (token && token !== localStorage.getItem('accessToken')) {
         store.dispatch('forceLogin', 'Token mismatch');
@@ -39,9 +39,9 @@ router.beforeEach((to, from, next) => {
     }
 
     if (!authed && to.matched.some(route => route.meta.auth)) {
-        nextpage = { name: 'login' };
+        nextpage.name = 'login';
     } else if (authed && to.matched.some(route => route.meta.guest)) {
-        nextpage = { name: 'dashboard' };
+        nextpage.name = 'dashboard';
     }
 
     next(nextpage);

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -68,12 +68,10 @@ export default {
     mounted() {
         this.initStatsBar();
 
-        const refreshStatsBar = () => {
-            return setInterval(
-                () => this.initStatsBar(),
-                REFRESH_INTERVAL_MS,
-            );
-        };
+        const refreshStatsBar = () => setInterval(
+            () => this.initStatsBar(),
+            REFRESH_INTERVAL_MS,
+        );
 
         let refreshStatsBarIntervalId = refreshStatsBar();
 

--- a/resources/js/components/StatsBar.vue
+++ b/resources/js/components/StatsBar.vue
@@ -102,7 +102,7 @@ export default {
                 return;
             }
             axios.get('/api/system-info').then(response => {
-                const data = response.data;
+                const { data } = response;
 
                 this.hostname = data.hostname;
                 this.cpu_usage = data.cpu;

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -65,11 +65,9 @@ export default {
     props: [
         'filePath',
     ],
-    data: () => {
-        return {
-            loading: false,
-        };
-    },
+    data: () => ({
+        loading: false,
+    }),
     computed: {
         ...mapGetters({
             file: 'files/file',
@@ -78,9 +76,7 @@ export default {
             modes: 'editor/modes',
         }),
         mappedModes() {
-            return this.modes.map(o => {
-                return { text: o.name, value: o.mime };
-            });
+            return this.modes.map(o => ({ text: o.name, value: o.mime }));
         },
         theme: {
             get() {

--- a/resources/js/pages/Sites/Detail.vue
+++ b/resources/js/pages/Sites/Detail.vue
@@ -203,8 +203,7 @@ export default {
             }
         },
         logNames(site) {
-            const s = 'object' === typeof site ? site
-                : this.findSite(parseInt(site));
+            const s = 'object' === typeof site ? site : this.findSite(parseInt(site));
 
             return Object.keys(s.logs);
         },
@@ -214,7 +213,8 @@ export default {
 
             axios.get(`/api/sites/${id}/logs/${this.activeLog}`).then(response => {
                 this.logContent = '' === response.data.trim()
-                    ? "Log file is empty or doesn't exist." : response.data;
+                    ? "Log file is empty or doesn't exist."
+                    : response.data;
             }).catch(() => {
                 this.logContent = `Failed to load ${this.activeLog} log!`;
             });

--- a/resources/js/store/modules/Auth.js
+++ b/resources/js/store/modules/Auth.js
@@ -29,50 +29,44 @@ export default {
         },
     },
     actions: {
-        register: data => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/register', {
-                    name: data.name,
-                    email: data.email,
-                    password: data.password,
-                    password_confirmation: data.passwordConfirmation,
-                }).then(response => {
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                });
+        register: data => new Promise((resolve, reject) => {
+            axios.post('/api/register', {
+                name: data.name,
+                email: data.email,
+                password: data.password,
+                password_confirmation: data.passwordConfirmation,
+            }).then(response => {
+                resolve(response);
+            }).catch(error => {
+                reject(error);
             });
-        },
-        login: ({ commit }, data) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/login', {
-                    username: data.username,
-                    password: data.password,
-                }).then(response => {
-                    commit('clearAlert');
-                    commit('setToken', response.data.access_token);
-                    resolve(response);
-                }).catch(error => {
-                    commit('clearAlert');
-                    commit('setAlert', {
-                        title: "We couldn't get you logged in :(",
-                        msg: error.response.data.message,
-                    });
-                    reject(error);
+        }),
+        login: ({ commit }, data) => new Promise((resolve, reject) => {
+            axios.post('/api/login', {
+                username: data.username,
+                password: data.password,
+            }).then(response => {
+                commit('clearAlert');
+                commit('setToken', response.data.access_token);
+                resolve(response);
+            }).catch(error => {
+                commit('clearAlert');
+                commit('setAlert', {
+                    title: "We couldn't get you logged in :(",
+                    msg: error.response.data.message,
                 });
+                reject(error);
             });
-        },
-        logout: ({ commit }) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/logout').then(response => {
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                }).then(() => {
-                    commit('clearToken');
-                });
+        }),
+        logout: ({ commit }) => new Promise((resolve, reject) => {
+            axios.post('/api/logout').then(response => {
+                resolve(response);
+            }).catch(error => {
+                reject(error);
+            }).then(() => {
+                commit('clearToken');
             });
-        },
+        }),
         fetchProfile: ({ commit }) => {
             axios.get('/api/user').then(response => {
                 commit('setUser', response.data);
@@ -86,8 +80,6 @@ export default {
     getters: {
         authMsg: state => state.alert,
         token: state => state.token,
-        loggedIn: state => {
-            return null !== state.token;
-        },
+        loggedIn: state => null !== state.token,
     },
 };

--- a/resources/js/store/modules/Database.js
+++ b/resources/js/store/modules/Database.js
@@ -16,36 +16,28 @@ export default {
         },
     },
     actions: {
-        load: ({ commit }) => {
-            return new Promise((resolve, reject) => {
-                axios.get('/api/databases').then(response => {
-                    commit('setDatabases', response.data);
-                    resolve(response);
-                }).catch(error => reject(error));
-            });
-        },
-        create: ({ commit, state }) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/databases', {
-                    database: state.search,
-                }).then(response => {
-                    commit('addDatabase', response.data);
-                    resolve(response);
-                }).catch(error => reject(error));
-            });
-        },
+        load: ({ commit }) => new Promise((resolve, reject) => {
+            axios.get('/api/databases').then(response => {
+                commit('setDatabases', response.data);
+                resolve(response);
+            }).catch(error => reject(error));
+        }),
+        create: ({ commit, state }) => new Promise((resolve, reject) => {
+            axios.post('/api/databases', {
+                database: state.search,
+            }).then(response => {
+                commit('addDatabase', response.data);
+                resolve(response);
+            }).catch(error => reject(error));
+        }),
         filter: ({ commit }, value) => {
             commit('setFilter', value);
         },
     },
     getters: {
-        all: state => {
-            return state.databases;
-        },
-        filtered: state => {
-            return state.databases.filter(db => {
-                return db.toLowerCase().includes(state.search.toLowerCase());
-            });
-        },
+        all: state => state.databases,
+        filtered: state => state.databases.filter(
+            db => db.toLowerCase().includes(state.search.toLowerCase()),
+        ),
     },
 };

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -102,14 +102,14 @@ export default {
         },
         async setMode({ commit }, value) {
             const filename = (/.+\.(?<ext>[^.]+)$/u).exec(value);
-            let mode;
+            let mode = '';
 
             const info = filename
                 ? CodeMirror.findModeByExtension(filename.groups.ext)
                 : CodeMirror.findModeByMIME(value);
 
             if (info) {
-                mode = info.mode;
+                ({ mode } = info);
                 commit('setSelectedMode', info.mime);
             }
 

--- a/resources/js/store/modules/FileManager.js
+++ b/resources/js/store/modules/FileManager.js
@@ -140,7 +140,7 @@ export default {
         file: state => state.file,
         currentPath: state => state.currentPath,
         errorData: () => error => {
-            let data = error.response.data;
+            let { data } = error.response;
 
             if (!data.error || !data.error.code) {
                 data = { error: {

--- a/resources/js/store/modules/FileManager.js
+++ b/resources/js/store/modules/FileManager.js
@@ -34,106 +34,92 @@ export default {
         },
     },
     actions: {
-        load: ({ commit, getters }, { path }) => {
-            return new Promise((resolve, reject) => {
-                axios.get('/api/files', {
-                    params: { path },
-                }).then(response => {
-                    commit('setPath', path);
-                    commit('setFiles', response.data);
-                    resolve(response);
-                }).catch(error => {
-                    const data = getters.errorData(error);
+        load: ({ commit, getters }, { path }) => new Promise((resolve, reject) => {
+            axios.get('/api/files', {
+                params: { path },
+            }).then(response => {
+                commit('setPath', path);
+                commit('setFiles', response.data);
+                resolve(response);
+            }).catch(error => {
+                const data = getters.errorData(error);
 
-                    commit('setPath', data.filepath);
-                    commit('setFiles', data);
-                    reject(error);
-                });
+                commit('setPath', data.filepath);
+                commit('setFiles', data);
+                reject(error);
             });
-        },
-        open: ({ commit, getters }, { file }) => {
-            return new Promise((resolve, reject) => {
-                commit('clearFile');
+        }),
+        open: ({ commit, getters }, { file }) => new Promise((resolve, reject) => {
+            commit('clearFile');
 
-                axios.get('/api/files/', {
-                    params: { file },
-                }).then(response => {
-                    commit('setPath', response.data.filepath);
-                    commit('setFile', response.data);
-                    resolve(response);
-                }).catch(error => {
-                    const data = getters.errorData(error);
+            axios.get('/api/files/', {
+                params: { file },
+            }).then(response => {
+                commit('setPath', response.data.filepath);
+                commit('setFile', response.data);
+                resolve(response);
+            }).catch(error => {
+                const data = getters.errorData(error);
 
-                    commit('setFile', data);
-                    reject(error);
-                });
+                commit('setFile', data);
+                reject(error);
             });
-        },
-        create: ({ commit, state }, path) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/files', {
-                    contents: state.file.contents,
-                    file: path,
-                }).then(response => {
-                    commit('setPath', response.data.filepath);
-                    commit('setFile', response.data);
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                });
+        }),
+        create: ({ commit, state }, path) => new Promise((resolve, reject) => {
+            axios.post('/api/files', {
+                contents: state.file.contents,
+                file: path,
+            }).then(response => {
+                commit('setPath', response.data.filepath);
+                commit('setFile', response.data);
+                resolve(response);
+            }).catch(error => {
+                reject(error);
             });
-        },
-        createDir: ({ commit }, path) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/files', {
-                    dir: path,
-                }).then(response => {
-                    commit('addFile', response.data);
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                });
+        }),
+        createDir: ({ commit }, path) => new Promise((resolve, reject) => {
+            axios.post('/api/files', {
+                dir: path,
+            }).then(response => {
+                commit('addFile', response.data);
+                resolve(response);
+            }).catch(error => {
+                reject(error);
             });
-        },
-        save: ({ commit, state }) => {
-            return new Promise((resolve, reject) => {
-                const fullpath = `${state.currentPath}/${state.file.filename}`;
+        }),
+        save: ({ commit, state }) => new Promise((resolve, reject) => {
+            const fullpath = `${state.currentPath}/${state.file.filename}`;
 
-                axios.put(`/api/files?file=${fullpath}`, {
-                    contents: state.file.contents,
-                }).then(response => {
-                    commit('setFile', response.data);
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                });
+            axios.put(`/api/files?file=${fullpath}`, {
+                contents: state.file.contents,
+            }).then(response => {
+                commit('setFile', response.data);
+                resolve(response);
+            }).catch(error => {
+                reject(error);
             });
-        },
-        rename: ({ commit }, { file, newPath }) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/files/rename', {
-                    oldPath: `${file.filepath}/${file.filename}`,
-                    newPath,
-                }).then(response => {
-                    commit('replaceFile', { oldFile: file, newFile: response.data });
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                });
+        }),
+        rename: ({ commit }, { file, newPath }) => new Promise((resolve, reject) => {
+            axios.post('/api/files/rename', {
+                oldPath: `${file.filepath}/${file.filename}`,
+                newPath,
+            }).then(response => {
+                commit('replaceFile', { oldFile: file, newFile: response.data });
+                resolve(response);
+            }).catch(error => {
+                reject(error);
             });
-        },
-        delete: ({ commit }, file) => {
-            return new Promise((resolve, reject) => {
-                const fullpath = `${file.filepath}/${file.filename}`;
+        }),
+        delete: ({ commit }, file) => new Promise((resolve, reject) => {
+            const fullpath = `${file.filepath}/${file.filename}`;
 
-                axios.delete(`/api/files?file=${fullpath}`).then(response => {
-                    commit('removeFile', file);
-                    resolve(response);
-                }).catch(error => {
-                    reject(error);
-                });
+            axios.delete(`/api/files?file=${fullpath}`).then(response => {
+                commit('removeFile', file);
+                resolve(response);
+            }).catch(error => {
+                reject(error);
             });
-        },
+        }),
     },
     getters: {
         all: state => state.files,

--- a/resources/js/store/modules/Site.js
+++ b/resources/js/store/modules/Site.js
@@ -82,14 +82,12 @@ export default {
         },
     },
     actions: {
-        load: ({ commit }) => {
-            return new Promise((resolve, reject) => {
-                axios.get('/api/sites').then(response => {
-                    commit('setSites', response.data);
-                    resolve(response);
-                }).catch(error => reject(error));
-            });
-        },
+        load: ({ commit }) => new Promise((resolve, reject) => {
+            axios.get('/api/sites').then(response => {
+                commit('setSites', response.data);
+                resolve(response);
+            }).catch(error => reject(error));
+        }),
         loadBranches: ({ commit, state }, repo = '') => {
             commit('branchesLoading');
             let url = `/api/sites/${state.current.id}/branches`;
@@ -109,16 +107,14 @@ export default {
             commit('setEditorSite', site);
             dispatch('loadBranches');
         },
-        create: ({ commit, state }) => {
-            return new Promise((resolve, reject) => {
-                axios.post('/api/sites', state.site).then(response => {
-                    commit('addSite', response.data);
-                    commit('clearMessages');
-                    commit('setSuccess', `The site '${response.data.name}' has been created.`);
-                    resolve(response);
-                }).catch(error => reject(error));
-            });
-        },
+        create: ({ commit, state }) => new Promise((resolve, reject) => {
+            axios.post('/api/sites', state.site).then(response => {
+                commit('addSite', response.data);
+                commit('clearMessages');
+                commit('setSuccess', `The site '${response.data.name}' has been created.`);
+                resolve(response);
+            }).catch(error => reject(error));
+        }),
         update: ({ commit }, site) => {
             axios.put(`/api/sites/${site.id}`, site.data).then(response => {
                 commit('clearMessages');
@@ -144,43 +140,27 @@ export default {
                 }
             });
         },
-        pull: site => {
-            return axios.post(`/api/sites/${site.id}/pull`);
-        },
-        delete: ({ commit }, id) => {
-            return new Promise((resolve, reject) => {
-                axios.delete(`/api/sites/${id}`).then(response => {
-                    commit('removeSite', id);
-                    resolve(response);
-                }).catch(error => {
-                    commit('setErrors', {
-                        message: error.message,
-                        action: 'delete',
-                    });
-                    reject(error);
+        pull: site => axios.post(`/api/sites/${site.id}/pull`),
+        delete: ({ commit }, id) => new Promise((resolve, reject) => {
+            axios.delete(`/api/sites/${id}`).then(response => {
+                commit('removeSite', id);
+                resolve(response);
+            }).catch(error => {
+                commit('setErrors', {
+                    message: error.message,
+                    action: 'delete',
                 });
+                reject(error);
             });
-        },
+        }),
     },
     getters: {
-        all: state => {
-            return state.sites;
-        },
-        filtered: state => {
-            return state.sites.filter(site => {
-                return site.name.toLowerCase().includes(state.currentFilter.toLowerCase());
-            });
-        },
-        findById: state => id => {
-            return state.sites.find(s => s.id === id);
-        },
-        findByDocroot: state => path => {
-            return state.sites.find(s => s.project_root === path);
-        },
-        branchOptions: state => {
-            return state.branches.map(b => {
-                return { text: b, value: b };
-            });
-        },
+        all: state => state.sites,
+        filtered: state => state.sites.filter(
+            site => site.name.toLowerCase().includes(state.currentFilter.toLowerCase()),
+        ),
+        findById: state => id => state.sites.find(s => s.id === id),
+        findByDocroot: state => path => state.sites.find(s => s.project_root === path),
+        branchOptions: state => state.branches.map(b => ({ text: b, value: b })),
     },
 };

--- a/resources/js/store/modules/System/Group.js
+++ b/resources/js/store/modules/System/Group.js
@@ -37,10 +37,10 @@ export default {
                 };
             }
 
-            state.clean = Object.assign({}, group);
+            state.clean = { ...group };
             state.clean.users = [ ...group.users ];
 
-            state.group = Object.assign({}, group);
+            state.group = { ...group };
             state.group.users = [ ...group.users ];
             state.group.gid_original = group.gid;
 

--- a/resources/js/store/modules/System/Group.js
+++ b/resources/js/store/modules/System/Group.js
@@ -108,27 +108,19 @@ export default {
         },
     },
     getters: {
-        all: state => {
-            return state.groups;
-        },
-        filtered: state => {
-            return state.groups.filter(group => {
-                if (!state.showSystem && SYSTEM_GID_THRESHOLD > group.gid) {
-                    return false;
-                }
+        all: state => state.groups,
+        filtered: state => state.groups.filter(group => {
+            if (!state.showSystem && SYSTEM_GID_THRESHOLD > group.gid) {
+                return false;
+            }
 
-                return group.name.includes(state.currentFilter);
-            });
-        },
-        dropdown: state => {
-            return state.groups.map(group => {
-                return {
-                    icon: 'users',
-                    text: `${group.gid} - ${group.name}`,
-                    value: group.gid,
-                };
-            });
-        },
+            return group.name.includes(state.currentFilter);
+        }),
+        dropdown: state => state.groups.map(group => ({
+            icon: 'users',
+            text: `${group.gid} - ${group.name}`,
+            value: group.gid,
+        })),
         groupIsDirty: state => {
             const now = state.group,
                 old = state.clean;

--- a/resources/js/store/modules/System/User.js
+++ b/resources/js/store/modules/System/User.js
@@ -46,10 +46,10 @@ export default {
                 };
             }
 
-            state.clean = Object.assign({}, user);
+            state.clean = { ...user };
             state.clean.groups = user.groups ? user.groups.slice(0) : [];
 
-            state.user = Object.assign({}, user);
+            state.user = { ...user };
             state.user.uid_original = user.uid;
 
             state.editing = true;

--- a/resources/js/store/modules/System/User.js
+++ b/resources/js/store/modules/System/User.js
@@ -130,27 +130,19 @@ export default {
         },
     },
     getters: {
-        all: state => {
-            return state.users;
-        },
-        filtered: state => {
-            return state.users.filter(user => {
-                if (!state.showSystem && SYSTEM_UID_THRESHOLD > user.uid) {
-                    return false;
-                }
+        all: state => state.users,
+        filtered: state => state.users.filter(user => {
+            if (!state.showSystem && SYSTEM_UID_THRESHOLD > user.uid) {
+                return false;
+            }
 
-                return user.name.includes(state.currentFilter);
-            });
-        },
-        dropdown: state => {
-            return state.users.map(user => {
-                return {
-                    icon: 'user',
-                    text: `${user.uid} - ${user.name}`,
-                    value: user.uid,
-                };
-            });
-        },
+            return user.name.includes(state.currentFilter);
+        }),
+        dropdown: state => state.users.map(user => ({
+            icon: 'user',
+            text: `${user.uid} - ${user.name}`,
+            value: user.uid,
+        })),
         userIsDirty: state => {
             const now = state.user,
                 old = state.clean;


### PR DESCRIPTION
Updates the following packages...

- Update vue-router (3.4.4 => 3.4.5)
- Update semantic-ui-vue (0.8.1 => 0.11.0)
- Update axios (0.19.2 => 0.20.0)
- Update resolve-url-loader (3.1.0 => 3.1.1)
- Update cross-env (6.0.3 => 7.0.2)
- Update sass-loader (8.0.2 => 10.0.2)
- Update eslint-plugin-vue (6.2.2 => 7.0.0-beta.4)
- Update eslint (6.8.0 => 7.10.0)

...and bumps eslint to use es2020 syntax while enabling some new and previously ignored rules.
