### PR TITLE
Set file editor mode based on filename

### DIFF
--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -101,12 +101,10 @@ export default {
             commit('setTheme', theme);
         },
         async setMode({ commit }, value) {
-            const filename = (/.+\.(?<ext>[^.]+)$/u).exec(value);
             let mode = '';
 
-            const info = filename
-                ? CodeMirror.findModeByExtension(filename.groups.ext)
-                : CodeMirror.findModeByMIME(value);
+            const info = CodeMirror.findModeByFileName(value)
+                ?? CodeMirror.findModeByMIME(value);
 
             if (info) {
                 ({ mode } = info);


### PR DESCRIPTION
Replaces `CodeMirror.findModeByExtension` with `CodeMirror.findModeByFileName` to detect nginx conf files properly.

If `findModeByFileName` doesn't match anything it automatically tries to find a match via `findModeByExtension`. If that fails to return info as well we try to determine a mode by calling `CodeMirror.findModeByMIME`.

This is the discussion + pr in the codemirror repo
https://github.com/codemirror/CodeMirror/issues/2940
https://github.com/codemirror/CodeMirror/pull/3027

Fixes #187 