### PR TITLE
Fix the installer when running in Vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,13 @@ dev-env:
 	@echo "[1/5] Destroying Vagrant VM and purging package caches..." && \
 		rm -rf ./composer ./node_modules ./vendor; vagrant destroy -f
 	@echo
-	@echo "[2/5] Installing Composer packages..."
+	@echo "[2/5] Installing Composer/NPM packages and building assets..."
 ifeq (, $(shell command -v composer))
 	@echo "Composer not available, package installation will run in Vagrant instead."
 else
 	@composer install --no-interaction --no-progress --no-suggest || true
 endif
+	@npm ci && npm run dev
 	@echo
 	@echo "[3/5] Creating the new VM..." && \
 		vagrant up --no-provision || true

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,12 @@ dev-env:
 	@echo "[1/5] Destroying Vagrant VM and purging package caches..." && \
 		rm -rf ./composer ./node_modules ./vendor; vagrant destroy -f
 	@echo
-	@echo "[2/5] Rebuilding the installer..." && \
-		make installer
+	@echo "[2/5] Installing Composer packages..."
+ifeq (, $(shell command -v composer))
+	@echo "Composer not available, package installation will run in Vagrant instead."
+else
+	@composer install --no-interaction --no-progress --no-suggest || true
+endif
 	@echo
 	@echo "[3/5] Creating the new VM..." && \
 		vagrant up --no-provision || true
@@ -29,7 +33,7 @@ dev-env:
 		vagrant provision --provision-with=user
 	@echo
 	@echo "[5/5] Restarting Vagrant VM to run installer..." && \
-		vagrant reload --provision-with=installer
+		make installer && vagrant reload --provision-with=installer
 
 test:
 	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml"

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,20 @@ installer:
 dev-env:
 	@echo "Go stick the kettle on, this'll take a while." && sleep 2
 	@echo
-	@echo "Destroying Vagrant VM and purging package caches..." && \
+	@echo "[1/5] Destroying Vagrant VM and purging package caches..." && \
 		rm -rf ./composer ./node_modules ./vendor; vagrant destroy -f
 	@echo
-	@echo "Restarting Vagrant VM to run installer..." && \
-		make installer && vagrant up
+	@echo "[2/5] Rebuilding the installer..." && \
+		make installer
+	@echo
+	@echo "[3/5] Creating the new VM..." && \
+		vagrant up --no-provision || true
+	@echo
+	@echo "[4/5] Creating the 'servidor' user..." && \
+		vagrant provision --provision-with=user
+	@echo
+	@echo "[5/5] Restarting Vagrant VM to run installer..." && \
+		vagrant reload --provision-with=installer
 
 test:
 	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 .PHONY: test
 
+GNU_SED := $(shell command -v gsed || command -v sed)
 now := `date '+%Y-%m-%d_%H%M'`
 
-installer:
+installer: thinkdifferent
 	@echo -n "Building unified install script... "
 	@cat build/installer/main.sh build/installer/_*.sh | \
-		sed -e '1,30s/echo "\(\s\+\[\)/echo "        \1/' \
+		$(GNU_SED) -e '1,30s/echo "\(\s\+\[\)/echo "        \1/' \
 			-e '1,20{/^# shellcheck source=_.*$$/,+1d}' \
 			-e '/^main "$$@"$$/{H;d};$${p;x;s/^\n//}' \
 			-e 's^main\.sh^bash ./setup.sh^' \
@@ -35,6 +36,12 @@ endif
 	@echo
 	@echo "[5/5] Restarting Vagrant VM to run installer..." && \
 		make installer && vagrant reload --provision-with=installer
+
+thinkdifferent:
+ifeq (Darwin,$(shell uname)$(shell command -v gsed))
+	@echo "To build the installer on OSX, you must first brew install gnu-sed"
+	@exit 1
+endif
 
 test:
 	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ installer:
 		> setup.sh
 	@chmod +x setup.sh && echo "Done!"
 
+dev-env:
+	@echo "Go stick the kettle on, this'll take a while." && sleep 2
+	@echo
+	@echo "Destroying Vagrant VM and purging package caches..." && \
+		rm -rf ./composer ./node_modules ./vendor; vagrant destroy -f
+	@echo
+	@echo "Restarting Vagrant VM to run installer..." && \
+		make installer && vagrant up
+
 test:
 	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ curl -s https://raw.githubusercontent.com/dshoreman/servidor/installer/setup.sh 
 
 ## Development
 
-Servidor is setup to use Vagrant for development. To get started, first clone the repository and run `vagrant up`.  
+To get started, run `make dev-env` in the project root. Servidor relies on [Vagrant] for development, so this command  
+takes care of creating the VM, running the necessary prep, and installation of Servidor within the dev environment.  
+After the initial setup, standard Vagrant commands can be used to `up`, `suspend`, `reload` and so on.
 
-Installation happens automatically as part of the provisioning process, but the installer will not build frontend assets if it
-detects Vagrant. Instead, you'll need to install and build them separately after running `vagrant up`:
+Due to memory constraints, static assets are not built during install in Vagrant.  
+Instead, install and build them separately once `make dev-env` has completed:
 
 ```sh
 # Clean-install NPM packages from the lock file
@@ -101,4 +103,5 @@ open an issue or pull request - the latter should go to the develop branch. Than
 [Development]: #development
 [Running Tests]: #running-tests
 [Contributing]: #contributing
+[Vagrant]: https://vagrantup.com
 [vagrant-hostsupdater]: https://github.com/agiledivider/vagrant-hostsupdater#installation

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Servidor is still very much a work in progress, but what has been [added so far]
 ## Table of Contents
 
 * [Introduction]
-* [Table of Contents]
 * [Installation]
+  * [Interactive Setup]
+  * [Startup Script]
 * [Development]
   * [Running Tests]
 * [Contributing]
@@ -26,7 +27,10 @@ you also have the ability to manually trigger a `git pull` on any given project 
 
 ## Installation
 
-> **WARNING!** Servidor is not yet ready for production use!
+> **NOTE: Servidor is still a work-in-progress!**  
+> As such, there are some parts that likely aren't as secure as they could be, so  
+> **exercise appropriate caution if you intend to use it on a public-facing server!**  
+> If you find anything that can be improved, PRs are open and greatly appreciated.
 
 #### Interactive Setup
 
@@ -63,25 +67,14 @@ To get started, run `make dev-env` in the project root. Servidor relies on [Vagr
 takes care of creating the VM, running the necessary prep, and installation of Servidor within the dev environment.  
 After the initial setup, standard Vagrant commands can be used to `up`, `suspend`, `reload` and so on.
 
-Due to memory constraints, static assets are not built during install in Vagrant.  
-Instead, install and build them separately once `make dev-env` has completed:
-
 ```sh
-# Clean-install NPM packages from the lock file
-npm ci
-
-# Compile the frontend assets for development
-npm run dev
+# tl;dr:
+git clone https://github.com/dshoreman/servidor.git
+cd servidor && make dev-env
 ```
 
-Alternatively, you can use `npm run watch` or `npm run hot` to have assets automatically rebuilt during development.
-
-By default, Servidor can be accessed at http://servidor.local:8042. If you have [vagrant-hostsupdater] or similar, this will be
-mapped automatically. Alternatively you can use http://192.168.10.100:8042, or run the following to update /etc/hosts:
-
-```sh
-echo '192.168.10.100 servidor.local' | sudo tee -a /etc/hosts
-```
+Due to memory constraints within the VM, static assets are initially built during `make dev-env`.  
+To recompile assets automatically when you make changes, run `npm run hot` or `npm run watch`.
 
 ### Running Tests
 
@@ -92,14 +85,18 @@ Other make commands are available such as `make syntax` to run other CI tools. F
 
 ## Contributing
 
-As noted above, Servidor is still very young. Your ideas, code and overall feedback are all highly valued, so please feel free to
-open an issue or pull request - the latter should go to the develop branch. Thanks! :heart:
+Where possible, issues are grouped into one of various projects based on the page/section they apply to, so if you want to
+find something to work on in a certain part of Servidor, then the Projects tab is a good place to start. Questions, bug reports,
+ideas and PRs are all welcome and highly appreciated, so don't be afraid to ask if there's something you're not sure of!
+
+If you use IRC, find me in *#servidor* on Freenode where I'll be happy to answer questions in a more real-time fashion.
 
 [Introduction]: #servidor
-[Table of Contents]: #table-of-contents
 [What it Does]: #what-it-does
 [added so far]: #what-it-does
 [Installation]: #installation
+[Interactive Setup]: #interactive-setup
+[Startup Script]: #startup-script
 [Development]: #development
 [Running Tests]: #running-tests
 [Contributing]: #contributing

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,27 +9,35 @@ Vagrant.configure("2") do |config|
   config.vm.network "private_network",
     ip: "192.168.10.100"
 
-  config.vm.synced_folder ".", "/vagrant",
-    disabled: true
-
-  config.vm.synced_folder ".", "/var/servidor",
-    create: true, owner: "998", group: "998",
-    mount_options: ["dmode=775,fmode=664"]
-
-  config.vm.synced_folder "./resources/test-skel", "/var/servidor/resources/test-skel",
-    create: false, owner: "www-data", group: "www-data",
-    mount_options: ["dmode=775,fmode=664"]
-
-  config.vm.synced_folder "./resources/test-skel/protected", "/var/servidor/resources/test-skel/protected",
-    create: false, owner: "vagrant", group: "vagrant",
-    mount_options: ["dmode=775,fmode=600"]
-
   config.vm.provider "virtualbox" do |vb|
     vb.name = "servidor-dev"
     vb.linked_clone = true
     vb.memory = "1024"
   end
 
-  config.vm.provision :shell, path: "setup.sh", args: "-v"
+  config.vm.provision "user", type: "shell", run: "never" do |s|
+    s.inline = "useradd -b /var -UG www-data -s /usr/sbin/nologin --system servidor && echo 'User added!'"
+  end
+
+  config.vm.provision "installer",
+    path: "setup.sh", args: "-v",
+    type: "shell", run: "never"
+
+  config.vm.synced_folder ".", "/vagrant",
+    disabled: true
+
+  config.vm.synced_folder ".", "/var/servidor",
+    create: true, owner: "servidor", group: "servidor",
+    mount_options: ["dmode=775,fmode=664"]
+
+  config.vm.synced_folder "./resources/test-skel",
+    "/var/servidor/resources/test-skel",
+    create: false, owner: "www-data", group: "www-data",
+    mount_options: ["dmode=775,fmode=664"]
+
+  config.vm.synced_folder "./resources/test-skel/protected",
+    "/var/servidor/resources/test-skel/protected",
+    create: false, owner: "vagrant", group: "vagrant",
+    mount_options: ["dmode=775,fmode=600"]
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,10 @@ Vagrant.configure("2") do |config|
     create: true, owner: "servidor", group: "servidor",
     mount_options: ["dmode=775,fmode=664"]
 
+  config.vm.synced_folder "./storage", "/var/servidor/storage",
+    create: false, owner: "servidor", group: "www-data",
+    mount_options: ["dmode=770,fmode=660"]
+
   config.vm.synced_folder "./resources/test-skel",
     "/var/servidor/resources/test-skel",
     create: false, owner: "www-data", group: "www-data",

--- a/build/installer/_install.sh
+++ b/build/installer/_install.sh
@@ -14,10 +14,12 @@ install_servidor() {
 }
 
 prepare_home() {
-    log " Creating servidor system user..."
-    useradd -b /var -UG www-data -s /usr/sbin/nologin --system servidor
     if ! is_vagrant; then
+        log "Creating servidor system user..."
+        useradd -b /var -UG www-data -s /usr/sbin/nologin --system servidor
         mkdir /var/servidor && chown servidor:servidor /var/servidor
+    else
+        log "Skipped system user creation - when running in Vagrant, this is done by make dev-env."
     fi
 
     log "Adding www-data to the servidor group..."
@@ -25,7 +27,7 @@ prepare_home() {
 }
 
 clone_and_install() {
-    cd /var/servidor || (err "Could not create system user!"; exit 1)
+    cd /var/servidor || (err "Home directory for servidor was not created!"; exit 1)
     if ! is_vagrant; then
         sudo -u servidor git clone -qb "${branch}" https://github.com/dshoreman/servidor.git .
     fi

--- a/build/installer/_install.sh
+++ b/build/installer/_install.sh
@@ -28,12 +28,13 @@ prepare_home() {
 
 clone_and_install() {
     cd /var/servidor || (err "Home directory for servidor was not created!"; exit 1)
+
     if ! is_vagrant; then
         sudo -u servidor git clone -qb "${branch}" https://github.com/dshoreman/servidor.git .
     fi
 
     log "Installing required Composer packages..."
-    is_vagrant && c_dev="" || c_dev="--no-dev"
+    is_vagrant && c_dev="--prefer-source" || c_dev="--no-dev"
     sudo -Hu servidor composer install ${c_dev} --no-interaction --no-progress --no-suggest
 
     log "Compiling static assets..."

--- a/setup.sh
+++ b/setup.sh
@@ -81,16 +81,18 @@ install_servidor() {
     finalise && print_success
 }
 prepare_home() {
-    log " Creating servidor system user..."
-    useradd -b /var -UG www-data -s /usr/sbin/nologin --system servidor
     if ! is_vagrant; then
+        log "Creating servidor system user..."
+        useradd -b /var -UG www-data -s /usr/sbin/nologin --system servidor
         mkdir /var/servidor && chown servidor:servidor /var/servidor
+    else
+        log "Skipped system user creation - when running in Vagrant, this is done by make dev-env."
     fi
     log "Adding www-data to the servidor group..."
     usermod -aG servidor www-data
 }
 clone_and_install() {
-    cd /var/servidor || (err "Could not create system user!"; exit 1)
+    cd /var/servidor || (err "Home directory for servidor was not created!"; exit 1)
     if ! is_vagrant; then
         sudo -u servidor git clone -qb "${branch}" https://github.com/dshoreman/servidor.git .
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -97,7 +97,7 @@ clone_and_install() {
         sudo -u servidor git clone -qb "${branch}" https://github.com/dshoreman/servidor.git .
     fi
     log "Installing required Composer packages..."
-    is_vagrant && c_dev="" || c_dev="--no-dev"
+    is_vagrant && c_dev="--prefer-source" || c_dev="--no-dev"
     sudo -Hu servidor composer install ${c_dev} --no-interaction --no-progress --no-suggest
     log "Compiling static assets..."
     if is_vagrant; then


### PR DESCRIPTION
This splits the Vagrant provisioning into a 3-step process to solve the issue with the servidor user needing to be created since we can't rely on IDs. When we're running in Vagrant, the installer will now skip user creation, leaving it to the `user` provisioner.

Issues with composer install are caused by a race condition due to a bug in Virtualbox, so to fix that we add the `--prefer-source` flag. That's incredibly slow though, so we also check for the existence of composer on the host and run it locally if possible via a new `dev-env` make target that will nuke all caches etc before reconstructing the whole environment.

Fixes #274 