### PR TITLE
Implement codemirror addons

### DIFF
--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -50,6 +50,7 @@ import 'codemirror/addon/selection/active-line.js';
 
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/edit/matchbrackets.js';
+import 'codemirror/addon/edit/trailingspace.js';
 import 'codemirror/addon/comment/continuecomment.js';
 
 import PathBar from '../../components/Files/PathBar';

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -48,6 +48,7 @@ import 'codemirror/addon/scroll/simplescrollbars.css';
 import 'codemirror/addon/scroll/simplescrollbars.js';
 import 'codemirror/addon/selection/active-line.js';
 
+import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/comment/continuecomment.js';
 
 import PathBar from '../../components/Files/PathBar';

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -48,6 +48,7 @@ import 'codemirror/addon/scroll/simplescrollbars.css';
 import 'codemirror/addon/scroll/simplescrollbars.js';
 import 'codemirror/addon/selection/active-line.js';
 
+import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/comment/continuecomment.js';
 

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -48,6 +48,8 @@ import 'codemirror/addon/scroll/simplescrollbars.css';
 import 'codemirror/addon/scroll/simplescrollbars.js';
 import 'codemirror/addon/selection/active-line.js';
 
+import 'codemirror/addon/fold/xml-fold.js';
+import 'codemirror/addon/edit/closetag.js';
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/trailingspace.js';

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -48,6 +48,8 @@ import 'codemirror/addon/scroll/simplescrollbars.css';
 import 'codemirror/addon/scroll/simplescrollbars.js';
 import 'codemirror/addon/selection/active-line.js';
 
+import 'codemirror/addon/comment/continuecomment.js';
+
 import PathBar from '../../components/Files/PathBar';
 import { codemirror } from 'vue-codemirror';
 import { mapGetters } from 'vuex';

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -43,6 +43,10 @@
 <script>
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/dracula.css';
+
+import 'codemirror/addon/scroll/simplescrollbars.css';
+import 'codemirror/addon/scroll/simplescrollbars.js';
+
 import PathBar from '../../components/Files/PathBar';
 import { codemirror } from 'vue-codemirror';
 import { mapGetters } from 'vuex';

--- a/resources/js/pages/Files/Editor.vue
+++ b/resources/js/pages/Files/Editor.vue
@@ -46,6 +46,7 @@ import 'codemirror/theme/dracula.css';
 
 import 'codemirror/addon/scroll/simplescrollbars.css';
 import 'codemirror/addon/scroll/simplescrollbars.js';
+import 'codemirror/addon/selection/active-line.js';
 
 import PathBar from '../../components/Files/PathBar';
 import { codemirror } from 'vue-codemirror';

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -16,6 +16,7 @@ export default {
             lineWrapping: true,
             lineNumbers: true,
             autofocus: true,
+            matchBrackets: true,
             continueComments: true,
             cursorScrollMargin: 75,
             scrollbarStyle: 'overlay',

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -13,6 +13,7 @@ export default {
             indentUnit: 4,
             tabSize: 4,
             styleActiveLine: true,
+            showTrailingSpace: true,
             lineWrapping: true,
             lineNumbers: true,
             autofocus: true,

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -19,6 +19,7 @@ export default {
             autofocus: true,
             matchBrackets: true,
             autoCloseBrackets: true,
+            autoCloseTags: true,
             continueComments: true,
             cursorScrollMargin: 75,
             scrollbarStyle: 'overlay',

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -16,6 +16,7 @@ export default {
             lineWrapping: true,
             lineNumbers: true,
             autofocus: true,
+            continueComments: true,
             cursorScrollMargin: 75,
             scrollbarStyle: 'overlay',
         },

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -17,6 +17,7 @@ export default {
             lineNumbers: true,
             autofocus: true,
             cursorScrollMargin: 75,
+            scrollbarStyle: 'overlay',
         },
         themes: [
             { text: '3024 Day', value: '3024-day' },

--- a/resources/js/store/modules/FileEditor.js
+++ b/resources/js/store/modules/FileEditor.js
@@ -17,6 +17,7 @@ export default {
             lineNumbers: true,
             autofocus: true,
             matchBrackets: true,
+            autoCloseBrackets: true,
             continueComments: true,
             cursorScrollMargin: 75,
             scrollbarStyle: 'overlay',

--- a/resources/sass/components/_codemirror.scss
+++ b/resources/sass/components/_codemirror.scss
@@ -15,4 +15,10 @@
     .CodeMirror, .vue-codemirror {
         height: 100%;
     }
+
+    .cm-trailingspace {
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QUXCToH00Y1UgAAACFJREFUCNdjPMDBUc/AwNDAAAFMTAwMDA0OP34wQgX/AQBYgwYEx4f9lQAAAABJRU5ErkJggg==);
+        background-position: bottom left;
+        background-repeat: repeat-x;
+    }
 }


### PR DESCRIPTION
This adds the following codemirror addons from #190:

- simplescrollbars
- active-line
- continuecomment
- matchbrackets
- closebrackets
- trailingspace (I ignored the idea with the ::before tag content because it only adds a single span for all trailing spaces and not a span per space)
- closetag