### PR TITLE
Initialize `theme` in localStorage if unset

### DIFF
--- a/resources/js/plugins/darkmode/index.js
+++ b/resources/js/plugins/darkmode/index.js
@@ -1,6 +1,12 @@
 export default {
     install(vue) {
         vue.mixin({
+            created() {
+                if (null === this.currentTheme) {
+                    this.currentTheme = 'light';
+                    localStorage.setItem('theme', this.currentTheme);
+                }
+            },
             computed: {
                 darkMode() {
                     return 'dark' === this.currentTheme;


### PR DESCRIPTION
Inside the mixinx created hook we can check if the currentTheme is null (not set in localStorage) and then set it to the default value of 'light'

To my understanding this should always work as data should be fully initialized and reactive when the "created" hook is called.

Fixes #289