### PR TITLE
Better CI workflow notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           channel: '#servidor'
           nickname: 'servidor-bot'
           message: |-
-            ${{ github.event.ref }} pushed to by ${{ github.actor }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.html_url }}
+            Completed build for PR #${{ github.event.number }} from ${{ github.event.pull_request.head.label }} (${{ github.event.pull_request.commits }} commits, +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}) (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.pull_request.html_url }}
       - if: github.event_name == 'workflow_dispatch'
         name: Send notification for manual trigger
         uses: rectalogic/notify-irc@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           branch=$(echo ${{github.event.ref}} | cut -d'/' -f3)
           echo "::set-output name=branch::$branch"
+          echo "::set-output name=commits::$(jq -r '.commits | length' $GITHUB_EVENT_PATH)"
       - if: github.event_name == 'push'
         name: Send notification for push event
         uses: rectalogic/notify-irc@v1
@@ -136,7 +137,7 @@ jobs:
           channel: '#servidor'
           nickname: 'servidor-bot'
           message: |-
-            ${{ github.event.ref }} pushed to by ${{ github.actor }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.compare }}
+            CI run completed on ${{ steps.get-ref.outputs.branch }} (${{ steps.get-ref.outputs.commits }} commit(s) pushed by ${{ github.actor }} Status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.compare }}
       - if: github.event_name == 'pull_request'
         name: Send failure notification (Pull Request)
         uses: rectalogic/notify-irc@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           channel: '#servidor'
           nickname: 'servidor-bot'
           message: |-
-            CI run completed on ${{ steps.get-ref.outputs.branch }} (${{ steps.get-ref.outputs.commits }} commit(s) pushed by ${{ github.actor }} Status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.compare }}
+            ${{ github.actor }} pushed ${{ steps.get-ref.outputs.commits }} commit(s) to ${{ steps.get-ref.outputs.branch }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.compare }}
       - if: github.event_name == 'pull_request'
         name: Send failure notification (Pull Request)
         uses: rectalogic/notify-irc@v1
@@ -145,7 +145,7 @@ jobs:
           channel: '#servidor'
           nickname: 'servidor-bot'
           message: |-
-            Completed build for PR #${{ github.event.number }} from ${{ github.event.pull_request.head.label }} (${{ github.event.pull_request.commits }} commits, +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}) (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.pull_request.html_url }}
+            ${{ github.actor }} pushed to PR #${{ github.event.number }} from ${{ github.event.pull_request.head.label }} (${{ github.event.pull_request.commits }} commits, +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}) (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.pull_request.html_url }}
       - if: github.event_name == 'workflow_dispatch'
         name: Send notification for manual trigger
         uses: rectalogic/notify-irc@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,9 @@ jobs:
     needs: [build-js, test-php]
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/workflow-conclusion-action@v2
+      - uses: dshoreman/workflow-conclusion-action@v2.2
+        with:
+          exclude_jobs: 'php-8.1 on ubuntu-.*$'
       - id: get-ref
         run: |
           branch=$(echo ${{github.event.ref}} | cut -d'/' -f3)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/workflow-conclusion-action@v2
-      - name: Send failure notification
+      - id: get-ref
+        run: |
+          branch=$(echo ${{github.event.ref}} | cut -d'/' -f3)
+          echo "::set-output name=branch::$branch"
+      - if: github.event_name == 'push'
+        name: Send notification for push event
         uses: rectalogic/notify-irc@v1
         with:
           channel: '#servidor'
           nickname: 'servidor-bot'
           message: |-
             ${{ github.event.ref }} pushed to by ${{ github.actor }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.compare }}
+      - if: github.event_name == 'workflow_dispatch'
+        name: Send notification for manual trigger
+        uses: rectalogic/notify-irc@v1
+        with:
+          channel: '#servidor'
+          nickname: 'servidor-bot'
+          message: |-
+            Manual CI run completed on ${{ steps.get-ref.outputs.branch }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Servidor CI
+name: build
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,14 @@ jobs:
           nickname: 'servidor-bot'
           message: |-
             ${{ github.event.ref }} pushed to by ${{ github.actor }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.compare }}
+      - if: github.event_name == 'pull_request'
+        name: Send failure notification (Pull Request)
+        uses: rectalogic/notify-irc@v1
+        with:
+          channel: '#servidor'
+          nickname: 'servidor-bot'
+          message: |-
+            ${{ github.event.ref }} pushed to by ${{ github.actor }} (status: ${{ env.WORKFLOW_CONCLUSION }}) - ${{ github.event.html_url }}
       - if: github.event_name == 'workflow_dispatch'
         name: Send notification for manual trigger
         uses: rectalogic/notify-irc@v1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Servidor
 
 [![GitHub release](https://img.shields.io/github/tag/dshoreman/servidor.svg?label=release)](https://github.com/dshoreman/servidor/releases)
-[![Build Status](https://travis-ci.com/dshoreman/servidor.svg?branch=develop)](https://travis-ci.com/dshoreman/servidor)
+[![Build Status](https://github.com/actions/servidor/workflows/build/badge.svg)](https://github.com/dshoreman/servidor/actions?query=workflow:build)
 [![codecov](https://codecov.io/gh/dshoreman/servidor/branch/develop/graph/badge.svg)](https://codecov.io/gh/dshoreman/servidor)
 [![Depfu](https://badges.depfu.com/badges/2c958ee33ec51367189f2762a8814dc5/count.svg)](https://depfu.com/github/dshoreman/servidor?project_id=5912)
 


### PR DESCRIPTION
This PR aims to fill some of the gaps left by the migration from TravisCI in #335.

**TODO:**
* [x] Add dedicated messages for push, PR and manual dispatch events
* [x] Improve notification messages to include useful data
* [x] Fix missing links in runs triggered by PR events
* [x] Fork workflow-conclusion-action to consider experimental jobs

Resolves the first part of #340