### PR TITLE
Fix PHPMD, Phan and PHP CS Fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ast
           coverage: pcov
       - name: Setup problem matchers
         run: |
@@ -81,7 +82,7 @@ jobs:
         run: |
           echo "::group::$ vendor/bin/php-cs-fixer fix"
           make phpcsf CS_ARGS="--verbose"
-          echo "::endgroup::\n::group::$ vendor/bin/phpcs --standard=PSR12"
+          echo -e "::endgroup::\n::group::$ vendor/bin/phpcs --standard=PSR12"
           make phpcs
           echo "::endgroup::"
       - name: Run PHP mess detection tool
@@ -92,9 +93,9 @@ jobs:
         run: |
           echo "::group::$ vendor/bin/phpstan analyze"
           make phpstan
-          echo "::endgroup::$ vendor/bin/phan"
+          echo -e "::endgroup::\n::group::$ vendor/bin/phan"
           make phan
-          echo "::endgroup::$ vendor/bin/psalm"
+          echo -e "::endgroup::\n::group::$ vendor/bin/psalm"
           make psalm
           echo "::endgroup::"
       - name: Run tests with PHPUnit

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -45,7 +45,11 @@ class RegisterController extends Controller
         return $user;
     }
 
-    /** @param Request $request @unused-param */
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @param Request $request @unused-param
+     */
     protected function registered(Request $request, User $user): JsonResponse
     {
         return response()->json($user);

--- a/app/Rules/Domain.php
+++ b/app/Rules/Domain.php
@@ -18,8 +18,6 @@ class Domain implements Rule
         ))\.?$/ixu';
 
     /**
-     * Determine if the validation rule passes.
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @param string $attribute @unused-param

--- a/app/Rules/NoColon.php
+++ b/app/Rules/NoColon.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Str;
 class NoColon implements Rule
 {
     /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
      * @param string $attribute @unused-param
      * @param mixed  $value
      */

--- a/app/Rules/NoComma.php
+++ b/app/Rules/NoComma.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Str;
 class NoComma implements Rule
 {
     /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
      * @param string $attribute @unused-param
      * @param mixed  $value
      */

--- a/app/Rules/NoWhitespace.php
+++ b/app/Rules/NoWhitespace.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Str;
 class NoWhitespace implements Rule
 {
     /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
      * @param string $attribute @unused-param
      * @param mixed  $value
      */

--- a/build/php-cs-fixer/config.php
+++ b/build/php-cs-fixer/config.php
@@ -4,6 +4,7 @@ $finder = (new PhpCsFixer\Finder())
     ->notName('*.blade.php')
     ->notName('_ide_helper.php')
     ->notPath('bootstrap/cache')
+    ->notPath('node_modules')
     ->notPath('storage')
     ->in(dirname(__DIR__, 2));
 

--- a/build/phpmd/CamelCaseVariableName.php
+++ b/build/phpmd/CamelCaseVariableName.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PHPMD\Rule\Servidor;
+
+use PHPMD\Rule\Controversial\CamelCaseVariableName as BaseRule;
+
+class CamelCaseVariableName extends BaseRule
+{
+    protected function isValid($variable): bool
+    {
+        if ('$_' === $variable->getImage()) {
+            return true;
+        }
+
+        return parent::isValid($variable);
+    }
+}

--- a/build/phpmd/rules.xml
+++ b/build/phpmd/rules.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
 <ruleset>
-    <rule ref="rulesets/design.xml" />
-    <rule ref="rulesets/unusedcode.xml" />
-
     <rule ref="rulesets/cleancode.xml">
         <exclude name="StaticAccess" />
         <exclude name="UndefinedVariable" />
@@ -27,7 +24,18 @@
         </properties>
     </rule>
 
+    <rule ref="rulesets/design.xml" />
+
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
+    </rule>
+
+    <rule ref="rulesets/unusedcode.xml">
+        <exclude name="UnusedLocalVariable" />
+    </rule>
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable">
+        <properties>
+            <property name="exceptions" value="_" />
+        </properties>
     </rule>
 </ruleset>

--- a/build/phpmd/rules.xml
+++ b/build/phpmd/rules.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <ruleset>
     <rule ref="rulesets/design.xml" />
-    <rule ref="rulesets/controversial.xml" />
     <rule ref="rulesets/unusedcode.xml" />
 
     <rule ref="rulesets/cleancode.xml">
@@ -14,6 +13,18 @@
     <rule ref="rulesets/codesize.xml">
         <exclude name="CyclomaticComplexity" />
         <exclude name="NPathComplexity" />
+    </rule>
+
+    <rule ref="rulesets/controversial.xml">
+        <exclude name="CamelCaseVariableName" />
+    </rule>
+    <rule name="CamelCaseVariableName"
+        message="The variable {0} is not named in camelCase."
+        class="PHPMD\Rule\Servidor\CamelCaseVariableName"
+        externalInfoUrl="#">
+        <properties>
+            <property name="allow-underscore" value="false" />
+        </properties>
     </rule>
 
     <rule ref="rulesets/naming.xml">

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
             "app/helpers.php"
         ],
         "psr-4": {
+            "PHPMD\\Rule\\Servidor\\": "build/phpmd/",
             "Servidor\\": "app/"
         }
     },


### PR DESCRIPTION
Adds a new rule for PHPMD so that we can allow `$_` in variable names
without suppressing the `CamelCaseVariableName` entirely, and adds an
exception for the `UnusedLocalVariable` rule so it doesn't complain.

Phan was failing in GH Actions due to lack of **php-ast**, so that has
been added to the `setup-php` job in our workflow. We also ignore the
**node_modules** directory for PHP CS Fixer to stop it spewing errors
within some random PHP files included from some random npm package.

Fixes #351.