### PR TITLE
Fix pre-commit autofixing of PHP files

### DIFF
--- a/build/hooks/pre-commit.sh
+++ b/build/hooks/pre-commit.sh
@@ -72,8 +72,15 @@ if [[ ${#stagedPhpFiles[@]} -gt 0 ]]; then
         git add "${file}"
     done
 
-    # Finally reset the rest and pop the stash
-    git checkout -- .
+    # All fixes added? If there's no stash, we're good to go!
+    mapfile -t postFixDirty < <(git diff-index --name-only --diff-filter=ACMR HEAD)
+    if [[ ${#postFixDirty[@]} -eq 0 ]] && [ $stashed = false ]; then
+        echo "${cGreen} All files fixed! Proceeding with commit${cEnd}"
+        exit 0
+    fi
+
+    # Otherwise, reset any changes and apply the stash...
+    [[ ${#postFixDirty[@]} -gt 0 ]] && git checkout -- .
     [ $stashed = true ] && git stash pop --quiet
 
     # ...before fixing one more time, but on all files, for a manual git add -p

--- a/build/hooks/pre-commit.sh
+++ b/build/hooks/pre-commit.sh
@@ -32,13 +32,6 @@ if [[ ! -f "$csFixerBin" ]] || [[ ! -x "$csFixerBin" ]]; then
 fi
 
 if [[ -n "${stagedProjectFiles}" ]]; then
-    let stashed=false
-    if [[ "$(git diff --name-only)" != "" ]]; then
-        echo "${cOrange} Found unstaged changes, stashing first!"
-        git stash push --keep-index -m PRECOMMIT
-        stashed=true
-    fi
-
     let phpFiles=0
     for file in $stagedProjectFiles; do if echo "$file" | egrep -q "\.(php)$"; then
         if ! php -l -d display_errors=0 "$file"; then
@@ -52,11 +45,5 @@ if [[ -n "${stagedProjectFiles}" ]]; then
         echo "${cGreen} Fixing files...${cEnd}"
         result=$( $csFixerBin fix --config=build/php-cs-fixer/config.php )
         echo "$result" | sed -e "s/\(.*\)/$cBlue\1$cEnd/g; s/\+  /$cGreen+  /g; s/-  /$cRed-  /g;"
-        git add --update
-    fi
-
-    if [ "$stashed" = true ]; then
-        echo "Restoring stashed changes..."
-        git stash pop --quiet
     fi
 fi

--- a/build/hooks/pre-commit.sh
+++ b/build/hooks/pre-commit.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
 cEnd=$'\e[0m'
-cOrange=$'\e[39m'
-cGreen=$'\e[36m'
+cOrange=$'\e[33m'
+cGreen=$'\e[32m'
 cRed=$'\e[31m'
 cBlue=$'\e[34m'
 
 csFixerBin=./vendor/bin/php-cs-fixer
-stagedProjectFiles=$(git diff-index --cached --name-only --diff-filter=ACMR HEAD -- )
-changedInstallFiles=$(git diff --cached --name-only | grep 'build/installer/' | wc -l | xargs)
+changedInstallFiles=$(git diff-index --cached --name-only HEAD | grep -c 'build/installer/')
 
 if [[ changedInstallFiles -gt 0 ]]; then
     echo "${cOrange}Detected change in install scripts, rebuilding installer!${cEnd}"
@@ -31,19 +30,58 @@ if [[ ! -f "$csFixerBin" ]] || [[ ! -x "$csFixerBin" ]]; then
     fi
 fi
 
-if [[ -n "${stagedProjectFiles}" ]]; then
-    let phpFiles=0
-    for file in $stagedProjectFiles; do if echo "$file" | egrep -q "\.(php)$"; then
+mapfile -t stagedPhpFiles < <(git diff-index --cached --name-only --diff-filter=ACMR HEAD | grep -E '\.(php)$')
+if [[ ${#stagedPhpFiles[@]} -gt 0 ]]; then
+    declare -a safeFiles
+    stashed=false
+
+    echo "${cBlue} Checking ${#stagedPhpFiles[@]} files for syntax errors${cEnd}"
+    for file in "${stagedPhpFiles[@]}"; do
         if ! php -l -d display_errors=0 "$file"; then
             echo "${cRed} File ${file} contains syntax errors.${cEnd}"
             echo && exit 2;
         fi
-        phpFiles+=1
-    fi; done
+        if git diff --quiet --name-only "${file}"; then
+            # Working copy is clean so file is fully staged and safe to fix
+            safeFiles+=("${file}")
+        fi
+    done
 
-    if [[ phpFiles -gt 0 ]]; then
-        echo "${cGreen} Fixing files...${cEnd}"
-        result=$( $csFixerBin fix --config=build/php-cs-fixer/config.php )
-        echo "$result" | sed -e "s/\(.*\)/$cBlue\1$cEnd/g; s/\+  /$cGreen+  /g; s/-  /$cRed-  /g;"
+    # Start by loading unstaged changes in PHP files
+    mapfile -t unstagedPhpFiles < <(git diff --name-only | grep -E '\.(php)$')
+
+    # So we can stash the changes we don't want to commit
+    if [[ ${#unstagedPhpFiles[@]} -gt 0 ]]; then
+        echo "${cBlue} Stashing unstaged changes from ${#unstagedPhpFiles[@]} PHP files${cEnd}"
+        git stash push --keep-index -m PRECOMMIT
+        stashed=true
     fi
+    # Then do a dry-run on staged files and exit if clean (real fix has unreliable exit codes)
+    if $csFixerBin fix --dry-run --config=build/php-cs-fixer/config.php; then
+        echo "${cGreen} Nothing to fix!${cEnd}"
+        [ $stashed = true ] && git stash pop --quiet
+        exit 0
+    fi
+
+    # Now fix for real, and add the safe files.
+    echo "${cGreen} Fixing files...${cEnd}"
+    result=$( $csFixerBin fix --config=build/php-cs-fixer/config.php )
+    echo "$result" | sed -e "s/\(.*\)/$cBlue\1$cEnd/g; s/\+  /$cGreen+  /g; s/-  /$cRed-  /g;"
+    for file in "${safeFiles[@]}"; do
+        echo "${cOrange} Adding fixes from ${file}${cEnd}"
+        git add "${file}"
+    done
+
+    # Finally reset the rest and pop the stash
+    git checkout -- .
+    [ $stashed = true ] && git stash pop --quiet
+
+    # ...before fixing one more time, but on all files, for a manual git add -p
+    result=$( $csFixerBin fix --config=build/php-cs-fixer/config.php )
+    echo "$result" | sed -e "s/\(.*\)/$cBlue\1$cEnd/g; s/\+  /$cGreen+  /g; s/-  /$cRed-  /g;"
+
+    echo "${cRed} Some files were fixed but could not be added automatically.${cEnd}"
+    echo "${cOrange}  Review the changes manually then re-commit with${cEnd}"
+    echo "${cOrange}   git commit -e --file .git/COMMIT_EDITMSG${cEnd}"
+    exit 3
 fi


### PR DESCRIPTION
I have a horrible habit of using git add --patch to partially stage
files, committing a big batch of changes in chunks that make sense.

Unfortunately, that causes havoc with the idea of stashing, fixing and
popping automatically before commit. In reality, it will often stash,
apply fixes, then throw its toys out the pram with a merge conflict.

A lot of the time, this results in committing changes that were unstaged
previously, as the conflict resolution screws up what was staged before.

This PR hopefully fixes the issue without risking loss of other changes.