### PR TITLE
Fix login being required in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [installer] Updated to install (and use) `php8.0-` packages and fpm socket
 
 ### Fixed
+* [auth] Opening Servidor in a new tab no longer requires you to login again
 * [installer] Fixed issue where password generation could trigger pipefail
 
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -29,11 +29,15 @@ const router = new VueRouter({
     routes,
 });
 
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
     const authed = store.getters.loggedIn, nextpage = {};
 
     if (!authed && to.matched.some(route => route.meta.auth)) {
-        nextpage.name = 'login';
+        await store.dispatch('fetchProfile');
+
+        if (!store.getters.loggedIn) {
+            nextpage.name = 'login';
+        }
     } else if (authed && to.matched.some(route => route.meta.guest)) {
         nextpage.name = 'dashboard';
     }


### PR DESCRIPTION
Since the `loggedIn` getter relies on there being a `user` object saved
in SessionStorage, opening links in a new tab results in a redirect back
to /login, even though the session may still be active and usable.

This resolves the issue by first attempting to re-fetch the profile
(which will set the `user` object back in SessionStorage) but *only*
when we're trying to fetch an authed page while seemingly "not authed".