### PR TITLE
Fix Promise.all() being too greedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * [auth] Opening Servidor in a new tab no longer requires you to login again
 * [installer] Fixed issue where password generation could trigger pipefail
+* [projects] Fixed app/redirect not getting saved with new projects
 
 
 ## [0.13.0] - 2021-05-25

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -225,21 +225,21 @@ export default {
 
             this.nextStep('redirect');
         },
-        async create(enabled = false) {
+        async create(enabled = false) { // eslint-disable-line max-statements
             this.setErrors({}, '');
 
             const [channel, step] = ['projects', this.progressInit()];
             let project = null;
 
             try {
-                [ project ] = await Promise.all([
-                    await this.$store.dispatch('projects/createProject', {
-                        name: this.project.name,
-                        is_enabled: enabled,
-                    }),
-                    this.$store.dispatch('progress/progress', { step: 'create', progress: 8 }),
+                project = await this.$store.dispatch('projects/createProject', {
+                    name: this.project.name,
+                    is_enabled: enabled,
+                });
+                await Promise.all([
+                    this.$store.dispatch('progress/progress', { step: STEP_CREATE, progress: 8 }),
                     this.$store.dispatch('progress/monitor', { channel, item: project.id }),
-                    this.$store.dispatch('progress/progress', { step: 'create', progress: 10 }),
+                    this.$store.dispatch('progress/progress', { step: STEP_CREATE, progress: 10 }),
                 ]);
 
                 const [action, data, progress] = step === STEP_APP


### PR DESCRIPTION
We previously moved everything into a single Promise.all to stop eslint
complaining about being one line over the max statements rule, but that
prevents the progress/monitor promise from using the `project` value.

This moves the primary project creation promise back into its own line
so that project is assigned first, then the rest can run normally.