### PR TITLE
Consolidate app/redirect {en,dis}able handling

### DIFF
--- a/app/Projects/Application.php
+++ b/app/Projects/Application.php
@@ -82,6 +82,16 @@ class Application extends Model
     /** @var string */
     private $templatesNamespace = 'Servidor\Projects\Applications\Templates\\';
 
+    public function disable(): void
+    {
+        $this->template()->disable();
+    }
+
+    public function enable(): void
+    {
+        $this->template()->enable();
+    }
+
     public function getDocumentRootAttribute(): string
     {
         return $this->sourceRoot . $this->template()->publicDir();
@@ -150,6 +160,11 @@ class Application extends Model
         } catch (UserNotFound $_) {
             return null;
         }
+    }
+
+    public function getType(): string
+    {
+        return 'application';
     }
 
     public function template(): Template

--- a/app/Projects/Applications/DeployApp.php
+++ b/app/Projects/Applications/DeployApp.php
@@ -17,7 +17,7 @@ class DeployApp
 
         if ($app->source_repository && $app->domain_name) {
             if ($project->is_enabled) {
-                $app->template()->pullCode(true);
+                $app->template()->pullCode();
 
                 ProjectProgress::dispatch($project, $step->complete());
 
@@ -25,12 +25,6 @@ class DeployApp
             }
 
             ProjectProgress::dispatch($project, $step->skip(ProgressStep::REASON_NOT_ENABLED));
-            $step = new ProgressStep('disable', 'Disabling project', 60);
-            ProjectProgress::dispatch($project, $step);
-
-            $app->template()->disable();
-
-            ProjectProgress::dispatch($project, $step->complete());
         }
     }
 }

--- a/app/Projects/Applications/ProjectAppSaved.php
+++ b/app/Projects/Applications/ProjectAppSaved.php
@@ -27,6 +27,11 @@ class ProjectAppSaved
         return $this->app;
     }
 
+    public function getAppOrRedirect(): Application
+    {
+        return $this->getApp();
+    }
+
     public function getProject(): Project
     {
         return $this->project;

--- a/app/Projects/Applications/Templates/Html.php
+++ b/app/Projects/Applications/Templates/Html.php
@@ -52,7 +52,7 @@ class Html implements Template, Domainable
         return $this->publicDir;
     }
 
-    public function pullCode(bool $autoEnable = false): bool
+    public function pullCode(): bool
     {
         $status = 0;
         $output = [];
@@ -66,9 +66,6 @@ class Html implements Template, Domainable
         }
         if (0 === $status) {
             exec($cmd, $output, $status);
-        }
-        if ($autoEnable && 0 === $status) {
-            $this->enable();
         }
 
         return 0 === $status;

--- a/app/Projects/Applications/Templates/Template.php
+++ b/app/Projects/Applications/Templates/Template.php
@@ -19,7 +19,7 @@ interface Template
 
     public function publicDir(): string;
 
-    public function pullCode(bool $autoEnable = false): bool;
+    public function pullCode(): bool;
 
     public function requiresUser(): bool;
 }

--- a/app/Projects/Redirect.php
+++ b/app/Projects/Redirect.php
@@ -59,6 +59,11 @@ class Redirect extends Model implements Domainable
         return $this->belongsTo(Project::class);
     }
 
+    public function getType(): string
+    {
+        return 'redirect';
+    }
+
     public function writeNginxConfig(): void
     {
         $view = view('projects.app-templates.redirect');

--- a/app/Projects/Redirects/ApplyRedirectNginxConfig.php
+++ b/app/Projects/Redirects/ApplyRedirectNginxConfig.php
@@ -17,8 +17,6 @@ class ApplyRedirectNginxConfig
 
         $redirect->writeNginxConfig();
 
-        $project->is_enabled ? $redirect->enable() : $redirect->disable();
-
         ProjectProgress::dispatch($project, $step->complete());
     }
 }

--- a/app/Projects/Redirects/ProjectRedirectSaved.php
+++ b/app/Projects/Redirects/ProjectRedirectSaved.php
@@ -22,6 +22,11 @@ class ProjectRedirectSaved
         $this->project = $redirect->project;
     }
 
+    public function getAppOrRedirect(): Redirect
+    {
+        return $this->getRedirect();
+    }
+
     public function getProject(): Project
     {
         return $this->project;

--- a/app/Projects/ToggleProjectVisibility.php
+++ b/app/Projects/ToggleProjectVisibility.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Servidor\Projects;
+
+use Servidor\Projects\Applications\ProjectAppSaved;
+
+class ToggleProjectVisibility
+{
+    public function handle(ProjectAppSaved $event): void
+    {
+        $app = $event->getApp();
+        $project = $event->getProject();
+
+        // This is required because TogglesNginxConfigs::configFilename()
+        // relies on the app's domain being set as configs are per-domain.
+        //
+        // TODO: If we switch to per-project configs, this can be removed.
+        if (!$app->domain_name) {
+            return;
+        }
+
+        if ($project->is_enabled) {
+            $app->template()->enable();
+
+            return;
+        }
+
+        $step = new ProgressStep('disable', 'Disabling project', 60);
+        ProjectProgress::dispatch($project, $step);
+
+        $app->template()->disable();
+
+        ProjectProgress::dispatch($project, $step->complete());
+    }
+}

--- a/app/Projects/ToggleProjectVisibility.php
+++ b/app/Projects/ToggleProjectVisibility.php
@@ -3,11 +3,19 @@
 namespace Servidor\Projects;
 
 use Servidor\Projects\Applications\ProjectAppSaved;
+use Servidor\Projects\Redirects\ProjectRedirectSaved;
 
 class ToggleProjectVisibility
 {
-    public function handle(ProjectAppSaved $event): void
+    public function handle(ProjectAppSaved|ProjectRedirectSaved $event): void
     {
+        if ($event instanceof ProjectRedirectSaved) {
+            $redirect = $event->getRedirect();
+            $event->getProject()->is_enabled ? $redirect->enable() : $redirect->disable();
+
+            return;
+        }
+
         $app = $event->getApp();
         $project = $event->getProject();
 

--- a/app/Projects/ToggleProjectVisibility.php
+++ b/app/Projects/ToggleProjectVisibility.php
@@ -10,39 +10,29 @@ class ToggleProjectVisibility
     public function handle(ProjectAppSaved|ProjectRedirectSaved $event): void
     {
         $project = $event->getProject();
-        $step = $this->step($event, $project);
+        $appOrRedirect = $event->getAppOrRedirect();
+        $step = $this->addStep($project, $appOrRedirect);
 
-        if ($event instanceof ProjectAppSaved) {
-            $this->toggleApplication($step, $project, $event->getApp());
-        }
-
-        if ($event instanceof ProjectRedirectSaved) {
-            $redirect = $event->getRedirect();
-            $project->is_enabled ? $redirect->enable() : $redirect->disable();
-        }
-
-        ProjectProgress::dispatch($project, $step->complete());
-    }
-
-    private function toggleApplication(ProgressStep $step, Project $project, Application $app): void
-    {
         // This is required because TogglesNginxConfigs::configFilename()
         // relies on the app's domain being set as configs are per-domain.
         //
         // TODO: If we switch to per-project configs, this can be removed.
-        if (!$app->domain_name) {
+        if (!$appOrRedirect->domain_name) {
             ProjectProgress::dispatch($project, $step->skip(ProgressStep::REASON_MISSING_DATA));
 
             return;
         }
 
-        $project->is_enabled ? $app->template()->enable() : $app->template()->disable();
+        $project->is_enabled ? $appOrRedirect->enable() : $appOrRedirect->disable();
+
+        ProjectProgress::dispatch($project, $step->complete());
     }
 
-    private function step(ProjectAppSaved|ProjectRedirectSaved $event, Project $project): ProgressStep
-    {
-        $type = $event instanceof ProjectAppSaved ? 'project' : 'redirect';
-        $text = ($project->is_enabled ? 'Enabling ' : 'Disabling ') . $type;
+    private function addStep(
+        Project $project,
+        Application|Redirect $appOrRedirect,
+    ): ProgressStep {
+        $text = ($project->is_enabled ? 'Enabling ' : 'Disabling ') . $appOrRedirect->getType();
 
         $step = new ProgressStep($project->is_enabled ? 'enable' : 'disable', $text, 60);
         ProjectProgress::dispatch($project, $step);

--- a/app/Projects/ToggleProjectVisibility.php
+++ b/app/Projects/ToggleProjectVisibility.php
@@ -11,7 +11,24 @@ class ToggleProjectVisibility
     {
         if ($event instanceof ProjectRedirectSaved) {
             $redirect = $event->getRedirect();
-            $event->getProject()->is_enabled ? $redirect->enable() : $redirect->disable();
+
+            if ($event->getProject()->is_enabled) {
+                $step = new ProgressStep('enable', 'Enabling redirect', 60);
+                ProjectProgress::dispatch($redirect, $step);
+
+                $redirect->enable();
+
+                ProjectProgress::dispatch($project, $step->complete());
+
+                return;
+            }
+
+            $step = new ProgressStep('disable', 'Disabling redirect', 60);
+            ProjectProgress::dispatch($redirect, $step);
+
+            $redirect->disable();
+
+            ProjectProgress::dispatch($project, $step->complete());
 
             return;
         }
@@ -28,7 +45,12 @@ class ToggleProjectVisibility
         }
 
         if ($project->is_enabled) {
+            $step = new ProgressStep('enable', 'Enabling project', 60);
+            ProjectProgress::dispatch($project, $step);
+
             $app->template()->enable();
+
+            ProjectProgress::dispatch($project, $step->complete());
 
             return;
         }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -12,6 +12,7 @@ use Servidor\Projects\Applications\ProjectAppSaved;
 use Servidor\Projects\Redirects\ApplyRedirectNginxConfig;
 use Servidor\Projects\Redirects\ProjectRedirectSaved;
 use Servidor\Projects\ReloadNginxService;
+use Servidor\Projects\ToggleProjectVisibility;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -20,6 +21,7 @@ class EventServiceProvider extends ServiceProvider
             CreateSystemUser::class,
             ApplyAppNginxConfig::class,
             DeployApp::class,
+            ToggleProjectVisibility::class,
             ReloadNginxService::class,
         ],
         ProjectRedirectSaved::class => [

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -26,6 +26,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         ProjectRedirectSaved::class => [
             ApplyRedirectNginxConfig::class,
+            ToggleProjectVisibility::class,
             ReloadNginxService::class,
         ],
         Registered::class => [


### PR DESCRIPTION
Previously enabling a project was part of the template's `pullCode`
method, which had to take a bool parameter to know if it should be
enabled automatically or not.

This PR moves both the enable and disable code into a new
`ToggleProjectVisibility` handler to simplify pull/deploy.

Closes #384.