### PR TITLE
Auto-create releases from tags using the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release-tagged:
+    name: Build release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate Changelog
+        run: |
+          TAG="${GITHUB_REF_NAME//./\.}"
+          echo "Generating changelog for ${TAG}..."
+          sed -n "/^## \[${TAG/v/}\]/,/^## \[/{//b;p}" CHANGELOG.md > ${{ github.workspace }}-changes.md
+          cat ${{ github.workspace }}-changes.md
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: ${{ github.workspace }}-changes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [projects] Progress step icons are now coloured (green, grey or red) based on step status
 * [projects] New 'working' `ProgressStep` state enables showing a progress spinner on start
 * [projects] Source Selector now supports v-model to prevent old form values being lost
+* [workflow] There's now a release action since GitHub decided to stop showing tags
 
 ### Changed
 * [chore] Dropped support for PHP 7.4


### PR DESCRIPTION
GitHub [no longer shows tags](https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/#the-papercuts-smaller-improvements) in the Releases list, so this adds a new workflow that will extract the matching version's changes from the changelog and use them to create a new release.