### PR TITLE
Fix php-pcov package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+* [installer] Fixed code coverage being unavailable in Vagrant
 
 
 ## [0.14.0] - 2021-11-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* [installer] Both PHP 8.0 and 8.1 are now installed to allow local testing in either
+
 ### Fixed
 * [installer] Fixed code coverage being unavailable in Vagrant
 

--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,10 @@ laravel-diff:
 test: test-8.0 test-8.1
 
 test-8.0:
-	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg8.0 -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
+	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg8.0 -qrr vendor/bin/phpunit -c build/phpunit/config.xml $(test)"
 
 test-8.1:
-	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg8.1 -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
+	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg8.1 -qrr vendor/bin/phpunit -c build/phpunit/config.xml $(test)"
 
 test-for-ci:
 	vendor/bin/phpunit -c build/phpunit/config.xml --coverage-clover=coverage.xml --exclude-group "broken-travis"

--- a/Makefile
+++ b/Makefile
@@ -96,18 +96,23 @@ laravel-diff:
 	@echo "Done! Opening diff tool..."
 	@meld /tmp/laradiff .
 
-test:
-	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
+test: test-8.0 test-8.1
+
+test-8.0:
+	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg8.0 -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
+
+test-8.1:
+	@vagrant ssh -c "cd /var/servidor && sudo -u www-data phpdbg8.1 -qrr vendor/bin/phpunit -c build/phpunit/config.xml"
 
 test-for-ci:
 	vendor/bin/phpunit -c build/phpunit/config.xml --coverage-clover=coverage.xml --exclude-group "broken-travis"
 
 coverage:
-	@vagrant ssh -c "cd /var/servidor && sudo -u www-data php vendor/bin/phpunit -c build/phpunit/config.xml --coverage-text"
+	@vagrant ssh -c "cd /var/servidor && sudo -u www-data php8.0 vendor/bin/phpunit -c build/phpunit/config.xml --coverage-text"
 	@echo
 
 coverage-html:
-	vagrant ssh -c "cd /var/servidor && sudo -u www-data php vendor/bin/phpunit -c build/phpunit/config.xml --coverage-html tests/reports/coverage/latest"
+	vagrant ssh -c "cd /var/servidor && sudo -u www-data php8.0 vendor/bin/phpunit -c build/phpunit/config.xml --coverage-html tests/reports/coverage/latest"
 	@mv tests/reports/coverage/latest tests/reports/coverage/$(now)/ && xdg-open ./tests/reports/coverage/$(now)/index.html
 	@echo
 

--- a/build/installer/_prepare.sh
+++ b/build/installer/_prepare.sh
@@ -43,7 +43,7 @@ install_packages() {
 
     is_vagrant && \
         log "Adding phpdbg and php-pcov for testing in Vagrant..." && \
-        phpexts+=(php-pcov php8.0-phpdbg)
+        phpexts+=(php8.0-pcov php8.0-phpdbg)
 
     install_pkg "${phpexts[@]}"
 

--- a/build/installer/_prepare.sh
+++ b/build/installer/_prepare.sh
@@ -5,7 +5,7 @@ start_install() {
     add_repos && install_packages
 
     info "Enabling services..."
-    enable_services mariadb nginx php8.0-fpm
+    enable_services mariadb nginx php8.1-fpm
 
     if is_vagrant; then
         info "Adding vagrant user to www-data group..."
@@ -31,27 +31,24 @@ add_repos() {
 }
 
 install_packages() {
-    local phpexts=(php8.0-bcmath php8.0-curl php8.0-mbstring php8.0-xml php8.0-zip)
+    local phpexts=(bcmath curl fpm mbstring mysql xml zip)
 
     info "Installing core packages..."
     install_pkg build-essential nodejs sysstat unzip zsh
 
     info "Installing database and web server..."
-    install_pkg nginx php8.0-fpm
+    install_pkg nginx mariadb-server
 
-    info "Installing required PHP extensions..."
+    info "Installing PHP and required extensions..."
 
     is_vagrant && \
         log "Adding phpdbg and php-pcov for testing in Vagrant..." && \
-        phpexts+=(php8.0-pcov php8.0-phpdbg)
+        phpexts+=(pcov phpdbg)
 
-    install_pkg "${phpexts[@]}"
+    install_php_extensions "${phpexts[@]}"
 
     info "Installing latest stable Composer..."
     install_composer
-
-    info "Installing database..."
-    install_pkg mariadb-server php8.0-mysql
 }
 
 install_composer() {
@@ -68,6 +65,16 @@ install_composer() {
         log " Checksums match! Starting install..."
         php $target --quiet --install-dir="/usr/local/bin" --filename="composer"
     fi
+}
+
+install_php_extensions() {
+    extensions=()
+
+    for ext in "$@"; do
+        extensions+=("php8.0-${ext}" "php8.1-${ext}")
+    done
+
+    install_pkg "${extensions[@]}"
 }
 
 install_pkg() {

--- a/setup.sh
+++ b/setup.sh
@@ -310,7 +310,7 @@ install_packages() {
     info "Installing required PHP extensions..."
     is_vagrant && \
         log "Adding phpdbg and php-pcov for testing in Vagrant..." && \
-        phpexts+=(php-pcov php8.0-phpdbg)
+        phpexts+=(php8.0-pcov php8.0-phpdbg)
     install_pkg "${phpexts[@]}"
     info "Installing latest stable Composer..."
     install_composer

--- a/setup.sh
+++ b/setup.sh
@@ -281,7 +281,7 @@ start_install() {
     info "Adding required repositories..."
     add_repos && install_packages
     info "Enabling services..."
-    enable_services mariadb nginx php8.0-fpm
+    enable_services mariadb nginx php8.1-fpm
     if is_vagrant; then
         info "Adding vagrant user to www-data group..."
         usermod -aG www-data vagrant
@@ -302,20 +302,18 @@ add_repos() {
     fi
 }
 install_packages() {
-    local phpexts=(php8.0-bcmath php8.0-curl php8.0-mbstring php8.0-xml php8.0-zip)
+    local phpexts=(bcmath curl fpm mbstring mysql xml zip)
     info "Installing core packages..."
     install_pkg build-essential nodejs sysstat unzip zsh
     info "Installing database and web server..."
-    install_pkg nginx php8.0-fpm
-    info "Installing required PHP extensions..."
+    install_pkg nginx mariadb-server
+    info "Installing PHP and required extensions..."
     is_vagrant && \
         log "Adding phpdbg and php-pcov for testing in Vagrant..." && \
-        phpexts+=(php8.0-pcov php8.0-phpdbg)
-    install_pkg "${phpexts[@]}"
+        phpexts+=(pcov phpdbg)
+    install_php_extensions "${phpexts[@]}"
     info "Installing latest stable Composer..."
     install_composer
-    info "Installing database..."
-    install_pkg mariadb-server php8.0-mysql
 }
 install_composer() {
     local expected actual target=/tmp/composer-setup.php
@@ -329,6 +327,13 @@ install_composer() {
         log " Checksums match! Starting install..."
         php $target --quiet --install-dir="/usr/local/bin" --filename="composer"
     fi
+}
+install_php_extensions() {
+    extensions=()
+    for ext in "$@"; do
+        extensions+=("php8.0-${ext}" "php8.1-${ext}")
+    done
+    install_pkg "${extensions[@]}"
 }
 install_pkg() {
     log "Packages to install: ${*}"


### PR DESCRIPTION
Seems the php repo now defaults to 8.1 for the php package, and pcov
must've slipped the net when all the others were defined. Installing
`php-pcov` causes PHPUnit to show a 'coverage not available' warning
since phpunit will be running under 8.0, but pcov is only under 8.1.

This adds *both* PHP 8.0 *and* PHP 8.1 to the installer.