### PR TITLE
Fix nginx symlink not being toggled on Project save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * [installer] Fixed code coverage being unavailable in Vagrant
+* [projects] The `sites-enabled/` symlink is now set correctly when saving projects
 
 
 ## [0.14.0] - 2021-11-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * [installer] Fixed code coverage being unavailable in Vagrant
 * [projects] The `sites-enabled/` symlink is now set correctly when saving projects
+* [projects] Fixed 502 on PHP/Laravel projects caused by running with old PHP version 
 
 
 ## [0.14.0] - 2021-11-12

--- a/app/Projects/Project.php
+++ b/app/Projects/Project.php
@@ -39,6 +39,10 @@ class Project extends Model
         'is_enabled' => 'boolean',
     ];
 
+    protected $dispatchesEvents = [
+        'saved' => ProjectSaved::class,
+    ];
+
     protected $table = 'projects';
 
     public function applications(): HasMany

--- a/app/Projects/ProjectSaved.php
+++ b/app/Projects/ProjectSaved.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Servidor\Projects;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\ItemNotFoundException;
+
+class ProjectSaved
+{
+    use SerializesModels;
+
+    public function __construct(
+        private Project $project,
+    ) {
+    }
+
+    public function getAppOrRedirect(): Application|Redirect|null
+    {
+        try {
+            return $this->project->applications->firstOrFail();
+        } catch (ItemNotFoundException $_) {
+            return $this->project->redirects->first();
+        }
+    }
+
+    public function getProject(): Project
+    {
+        return $this->project;
+    }
+}

--- a/app/Projects/ProjectSaved.php
+++ b/app/Projects/ProjectSaved.php
@@ -16,41 +16,21 @@ class ProjectSaved
         $this->project = $project;
     }
 
-    public function getApp(): ?Application
-    {
-        /** @var array<Application>|Collection<Application>|null $apps */
-        $apps = $this->project->applications ?? null;
-
-        if (!$apps || ($apps instanceof Collection && $apps->isEmpty())) {
-            return null;
-        }
-
-        return \is_array($apps)
-            ? array_values($apps)[0]
-            : $apps->first();
-    }
-
     public function getAppOrRedirect(): Application|Redirect|null
     {
-        return $this->getApp() ?? $this->getRedirect();
+        /** @var array<Application>|Collection<Application> $apps */
+        $apps = $this->project->applications;
+        \assert($apps instanceof Collection);
+
+        /** @var array<Redirect>|Collection<Redirect> $redirects */
+        $redirects = $this->project->redirects;
+        \assert($redirects instanceof Collection);
+
+        return $apps->first() ?? $redirects->first();
     }
 
     public function getProject(): Project
     {
         return $this->project;
-    }
-
-    public function getRedirect(): ?Redirect
-    {
-        /** @var array<Redirect>|Collection<Redirect>|null $redirects */
-        $redirects = $this->project->redirects ?? null;
-
-        if (!$redirects || ($redirects instanceof Collection && $redirects->isEmpty())) {
-            return null;
-        }
-
-        return \is_array($redirects)
-            ? array_values($redirects)[0]
-            : $redirects->first();
     }
 }

--- a/app/Projects/ProjectSaved.php
+++ b/app/Projects/ProjectSaved.php
@@ -2,29 +2,55 @@
 
 namespace Servidor\Projects;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\ItemNotFoundException;
 
 class ProjectSaved
 {
     use SerializesModels;
 
-    public function __construct(
-        private Project $project,
-    ) {
+    private Project $project;
+
+    public function __construct(Project $project)
+    {
+        $this->project = $project;
+    }
+
+    public function getApp(): ?Application
+    {
+        /** @var array<Application>|Collection<Application>|null $apps */
+        $apps = $this->project->applications ?? null;
+
+        if (!$apps || ($apps instanceof Collection && $apps->isEmpty())) {
+            return null;
+        }
+
+        return \is_array($apps)
+            ? array_values($apps)[0]
+            : $apps->first();
     }
 
     public function getAppOrRedirect(): Application|Redirect|null
     {
-        try {
-            return $this->project->applications->firstOrFail();
-        } catch (ItemNotFoundException $_) {
-            return $this->project->redirects->first();
-        }
+        return $this->getApp() ?? $this->getRedirect();
     }
 
     public function getProject(): Project
     {
         return $this->project;
+    }
+
+    public function getRedirect(): ?Redirect
+    {
+        /** @var array<Redirect>|Collection<Redirect>|null $redirects */
+        $redirects = $this->project->redirects ?? null;
+
+        if (!$redirects || ($redirects instanceof Collection && $redirects->isEmpty())) {
+            return null;
+        }
+
+        return \is_array($redirects)
+            ? array_values($redirects)[0]
+            : $redirects->first();
     }
 }

--- a/app/Projects/ToggleProjectVisibility.php
+++ b/app/Projects/ToggleProjectVisibility.php
@@ -7,10 +7,14 @@ use Servidor\Projects\Redirects\ProjectRedirectSaved;
 
 class ToggleProjectVisibility
 {
-    public function handle(ProjectAppSaved|ProjectRedirectSaved $event): void
+    public function handle(ProjectSaved|ProjectAppSaved|ProjectRedirectSaved $event): void
     {
         $project = $event->getProject();
         $appOrRedirect = $event->getAppOrRedirect();
+
+        if (null === $appOrRedirect) {
+            return;
+        }
         $step = $this->addStep($project, $appOrRedirect);
 
         // This is required because TogglesNginxConfigs::configFilename()

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,6 +9,7 @@ use Servidor\Projects\Applications\ApplyAppNginxConfig;
 use Servidor\Projects\Applications\CreateSystemUser;
 use Servidor\Projects\Applications\DeployApp;
 use Servidor\Projects\Applications\ProjectAppSaved;
+use Servidor\Projects\ProjectSaved;
 use Servidor\Projects\Redirects\ApplyRedirectNginxConfig;
 use Servidor\Projects\Redirects\ProjectRedirectSaved;
 use Servidor\Projects\ReloadNginxService;
@@ -17,6 +18,10 @@ use Servidor\Projects\ToggleProjectVisibility;
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
+        ProjectSaved::class => [
+            ToggleProjectVisibility::class,
+            ReloadNginxService::class,
+        ],
         ProjectAppSaved::class => [
             CreateSystemUser::class,
             ApplyAppNginxConfig::class,

--- a/resources/views/projects/app-templates/php.blade.php
+++ b/resources/views/projects/app-templates/php.blade.php
@@ -10,7 +10,7 @@ server {
         location ~ \.php$ {
             try_files $uri =404;
 
-            fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 

--- a/tests/Feature/Api/Projects/Applications/PullCodeTest.php
+++ b/tests/Feature/Api/Projects/Applications/PullCodeTest.php
@@ -33,7 +33,11 @@ class PullCodeTest extends TestCase
         $response->assertJsonCount(1);
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
         $response->assertJson(['message' => 'Unauthenticated.']);
-        $this->assertArraySubset($project->toArray(), Project::with('applications')->firstOrFail()->toArray());
+
+        self::assertArraySubset(
+            $project->toArray(),
+            Project::with(['applications', 'redirects'])->firstOrFail()->toArray(),
+        );
     }
 
     /** @test */

--- a/tests/Feature/Api/Projects/RemoveProjectTest.php
+++ b/tests/Feature/Api/Projects/RemoveProjectTest.php
@@ -25,7 +25,11 @@ class RemoveProjectTest extends TestCase
         $response->assertJsonCount(1);
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
         $response->assertJson(['message' => 'Unauthenticated.']);
-        $this->assertArraySubset($project->toArray(), Project::firstOrFail()->toArray());
+
+        self::assertArraySubset(
+            $project->toArray(),
+            Project::with(['applications', 'redirects'])->firstOrFail()->toArray(),
+        );
     }
 
     /** @test */

--- a/tests/Feature/Api/Projects/UpdateProjectTest.php
+++ b/tests/Feature/Api/Projects/UpdateProjectTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api\Projects;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Response;
+use Illuminate\Support\Str;
 use Servidor\Projects\Project;
 use Tests\RequiresAuth;
 use Tests\TestCase;
@@ -14,6 +15,13 @@ class UpdateProjectTest extends TestCase
     use ArraySubsetAsserts;
     use RefreshDatabase;
     use RequiresAuth;
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        exec('sudo rm -f /etc/nginx/sites-*/*-symlink.test.conf');
+    }
 
     /** @test */
     public function guest_cannot_update_project(): void
@@ -86,33 +94,49 @@ class UpdateProjectTest extends TestCase
 
     /**
      * @test
+     * @dataProvider symlinkProvider
      */
-    public function updating_project_also_toggles_symlink(): void
+    public function updating_project_also_toggles_symlink(string $type, array $data): void
     {
-        $project = new Project(['name' => 'Symlink Test', 'is_enabled' => true]);
+        $name = $type . ' Symlink Test';
+        $domain = $type . '-symlink.test';
+
+        $this->assertFileDoesNotExist("/etc/nginx/sites-available/{$domain}.conf");
+        $this->assertFileDoesNotExist("/etc/nginx/sites-enabled/{$domain}.conf");
+        $project = new Project(['name' => $name, 'is_enabled' => true]);
         $project->save();
 
-        $this->authed()->postJson("/api/projects/{$project->id}/apps", [
-            'domain' => 'symlink.test',
-            'template' => 'html',
-            'provider' => 'github',
-            'repository' => 'dshoreman/servidor-test-site',
-            'branch' => 'develop',
-        ]);
-        $this->assertFileExists('/etc/nginx/sites-available/symlink.test.conf');
-        $this->assertFileExists('/etc/nginx/sites-enabled/symlink.test.conf');
+        $this->authed()->postJson(
+            '/api/projects/' . $project->id . '/' . Str::plural($type),
+            array_merge(['domain' => $domain], $data),
+        );
+        $this->assertFileExists("/etc/nginx/sites-available/{$domain}.conf");
+        $this->assertFileExists("/etc/nginx/sites-enabled/{$domain}.conf");
 
-        $response = $this->authed()->putJson('/api/projects/' . $project->id, [
+        $response = $this->authed()->putJson("/api/projects/{$project->id}", [
             'is_enabled' => false,
         ]);
 
         $response->assertOk();
-        $response->assertJsonFragment([
-            'name' => 'Symlink Test',
-            'is_enabled' => false,
-        ]);
-        $this->assertFileExists('/etc/nginx/sites-available/symlink.test.conf');
-        $this->assertFileDoesNotExist('/etc/nginx/sites-enabled/symlink.test.conf');
+        $response->assertJsonFragment(['name' => $name, 'is_enabled' => false]);
+        $this->assertFileExists("/etc/nginx/sites-available/{$domain}.conf");
+        $this->assertFileDoesNotExist("/etc/nginx/sites-enabled/{$domain}.conf");
+    }
+
+    public function symlinkProvider(): array
+    {
+        return [
+            'Project with an application' => ['app', [
+                'template' => 'html',
+                'provider' => 'github',
+                'repository' => 'dshoreman/servidor-test-site',
+                'branch' => 'develop',
+            ]],
+            'Project with a redirect' => ['redirect', [
+                'target' => 'example.com',
+                'type' => 301,
+            ]],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
Adds a `ProjectSaved` event on the Project model so we can dispatch the required actions/jobs/tasks to add/remove the symlink in `nginx/sites-enabled` and reload nginx.

Also fixes the PHP version used in the default nginx template. Previously it was 7.4 which wasn't installed, so it threw a 502 Bad Gateway on and PHP or Laravel projects.