### PR TITLE
Add dropdown to choose between custom or archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [projects] The `www.` subdomain can now be auto-included in `server_name`
 * [projects] Fully custom target domains can now be set when creating redirects
 * [projects] Redirect targets can now have `$request_uri` appended during creation
+* [projects] When creating redirects, there is now a preview of the generated rule
 
 ### Fixed
 * [installer] Fixed code coverage being unavailable in Vagrant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * [installer] Both PHP 8.0 and 8.1 are now installed to allow local testing in either
 * [projects] The `www.` subdomain can now be auto-included in `server_name`
+* [projects] Fully custom target domains can now be set when creating redirects
 
 ### Fixed
 * [installer] Fixed code coverage being unavailable in Vagrant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [installer] Both PHP 8.0 and 8.1 are now installed to allow local testing in either
 * [projects] The `www.` subdomain can now be auto-included in `server_name`
 * [projects] Fully custom target domains can now be set when creating redirects
+* [projects] Redirect targets can now have `$request_uri` appended during creation
 
 ### Fixed
 * [installer] Fixed code coverage being unavailable in Vagrant
 * [projects] The `sites-enabled/` symlink is now set correctly when saving projects
 * [projects] Fixed 502 on PHP/Laravel projects caused by running with old PHP version 
-* [projects] Ensure `$request_uri` is appended to redirect targets
 
 
 ## [0.14.0] - 2021-11-12

--- a/resources/js/components/Projects/Apps/RedirectForm.vue
+++ b/resources/js/components/Projects/Apps/RedirectForm.vue
@@ -1,31 +1,15 @@
 <template>
     <sui-form @submit.prevent="save()">
 
-        <sui-form-field :error="'target' in errors">
-
-            <label>Archived Domain</label>
-
-            <sui-input v-model="target" placeholder="example.com" required />
-
-            <sui-label basic color="red" pointing v-if="'target' in errors">
-                {{ errors['target'][0] }}
-            </sui-label>
-
-        </sui-form-field>
-
         <sui-form-fields>
-            <sui-form-field :width="10">
-                <label>Archive Date</label>
-                <sui-form-fields>
-                    <sui-form-field :width="9">
-                        <sui-input type="date" v-model="date" />
-                    </sui-form-field>
-                    <sui-form-field :width="7">
-                        <sui-input type="time" v-model="time" step="1" />
-                    </sui-form-field>
-                </sui-form-fields>
+            <sui-form-field :width="9">
+                <label>Rule Template</label>
+                <sui-dropdown selection v-model="ruleTpl"
+                    :options="[{ text: 'Archive (via WayBack Machine)', value: 'archive' },
+                               { text: 'Custom', value: 'custom' }]" />
             </sui-form-field>
-            <sui-form-field :width="6" :error="'type' in errors">
+
+            <sui-form-field :width="7" :error="'type' in errors">
                 <label>Redirect Type</label>
                 <sui-dropdown :options="[{ text: 'Temporary', value: 302 },
                                          { text: 'Permanent', value: 301 }]"
@@ -35,6 +19,26 @@
                 </sui-label>
             </sui-form-field>
         </sui-form-fields>
+
+        <sui-form-field :error="'target' in errors">
+            <label>{{ 'archive' === ruleTpl ? 'Archived' : 'Target' }} Domain</label>
+            <sui-input v-model="target" placeholder="example.com" required />
+            <sui-label basic color="red" pointing v-if="'target' in errors">
+                {{ errors['target'][0] }}
+            </sui-label>
+        </sui-form-field>
+
+        <sui-form-field v-show="'archive' === ruleTpl">
+            <label>Archive Date</label>
+            <sui-form-fields>
+                <sui-form-field :width="9">
+                    <sui-input type="date" v-model="date" />
+                </sui-form-field>
+                <sui-form-field :width="7">
+                    <sui-input type="time" v-model="time" step="1" />
+                </sui-form-field>
+            </sui-form-fields>
+        </sui-form-field>
 
         <step-buttons @cancel="$emit('cancel')" />
 
@@ -57,6 +61,7 @@ export default {
             date: '',
             time: '',
             target: '',
+            ruleTpl: 'custom',
             type: 301,
         };
     },
@@ -67,7 +72,10 @@ export default {
 
             date = date.replaceAll('-', '');
             time = time.replaceAll(':', '');
-            target = `https://web.archive.org/web/${date}${time}/${target}`;
+
+            if ('archive' === this.ruleTpl) {
+                target = `https://web.archive.org/web/${date}${time}/${target}`;
+            }
 
             this.$emit('next', { domain, target, type });
         },

--- a/resources/js/components/Projects/Apps/RedirectForm.vue
+++ b/resources/js/components/Projects/Apps/RedirectForm.vue
@@ -28,6 +28,10 @@
             </sui-label>
         </sui-form-field>
 
+        <sui-form-field>
+            <sui-checkbox toggle v-model="appendRequest" label="Append source request URI" />
+        </sui-form-field>
+
         <sui-form-field v-show="'archive' === ruleTpl">
             <label>Archive Date</label>
             <sui-form-fields>
@@ -62,6 +66,7 @@ export default {
             time: '',
             target: '',
             ruleTpl: 'custom',
+            appendRequest: false,
             type: 301,
         };
     },
@@ -75,6 +80,10 @@ export default {
 
             if ('archive' === this.ruleTpl) {
                 target = `https://web.archive.org/web/${date}${time}/${target}`;
+            }
+
+            if (this.appendRequest) {
+                target += '$request_uri';
             }
 
             this.$emit('next', { domain, target, type });

--- a/resources/js/components/Projects/Apps/RedirectForm.vue
+++ b/resources/js/components/Projects/Apps/RedirectForm.vue
@@ -44,6 +44,11 @@
             </sui-form-fields>
         </sui-form-field>
 
+        <sui-form-field v-show="target">
+            <label>Rule Preview</label>
+            <code>{{ realTarget }}</code>
+        </sui-form-field>
+
         <step-buttons @cancel="$emit('cancel')" />
 
     </sui-form>
@@ -70,9 +75,8 @@ export default {
             type: 301,
         };
     },
-    methods: {
-        save() {
-            const { domain, type } = this;
+    computed: {
+        realTarget() {
             let { date, target, time } = this;
 
             date = date.replaceAll('-', '');
@@ -86,7 +90,14 @@ export default {
                 target += '$request_uri';
             }
 
-            this.$emit('next', { domain, target, type });
+            return target;
+        },
+    },
+    methods: {
+        save() {
+            const { domain, realTarget, type } = this;
+
+            this.$emit('next', { domain, target: realTarget, type });
         },
     },
 };

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -30,7 +30,7 @@
             </sui-segment>
 
             <sui-segment v-else-if="step == 'redirect'">
-                <h3 is="sui-header">Configure the preferred target archive on WayBack Machine</h3>
+                <h3 is="sui-header">Time to set the target!</h3>
                 <redirect-form :errors="errors" :domain="defaultApp.domain"
                     @next="setRedirect" @cancel="cancel" />
             </sui-segment>

--- a/resources/js/pages/Projects/steps.json
+++ b/resources/js/pages/Projects/steps.json
@@ -18,9 +18,9 @@
 }, {
   "disabled": true,
   "errorKeys": ["type", "target"],
-  "icon": "archive",
+  "icon": "exchange",
   "name": "redirect",
-  "title": "Archived Copy"
+  "title": "Redirection"
 }, {
   "disabled": true,
   "errorKey": "name",

--- a/resources/views/projects/app-templates/redirect.blade.php
+++ b/resources/views/projects/app-templates/redirect.blade.php
@@ -5,5 +5,5 @@ server {
     server_name {{ $redirect->domain_name }};
 @endif
 
-    return {{ $redirect->type }} {{ $redirect->target }}$request_uri;
+    return {{ $redirect->type }} {{ $redirect->target }};
 }

--- a/tests/Unit/Projects/RedirectTest.php
+++ b/tests/Unit/Projects/RedirectTest.php
@@ -66,7 +66,7 @@ class RedirectTest extends TestCase
 
         $this->assertFileExists($config = storage_path('app/vhosts/a-redir.example.conf'));
         $this->assertStringContainsString('server_name a-redir.example;', $txt = file_get_contents($config));
-        $this->assertStringContainsString('return 301 b-redir.example$request_uri;', $txt = file_get_contents($config));
+        $this->assertStringContainsString('return 301 b-redir.example;', $txt = file_get_contents($config));
     }
 
     public static function tearDownAfterClass(): void


### PR DESCRIPTION
Moves the redirect type dropdown to the top of the form alongside a new
'Rule Template' dropdown with options for either custom or WBM archives.

With this, the fields related to WayBack Machine archive date/time now
use the full form width and will not be visible if 'Custom' is chosen.

Also makes the appending of `$request_uri` settable, and adds a rule
preview.