### PR TITLE
Add ability to set PHP version per-project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* [projects] PHP version can now be set when creating a project
 
 
 ## [0.15.3] - 2023-01-08

--- a/app/Http/Requests/Projects/NewProjectApp.php
+++ b/app/Http/Requests/Projects/NewProjectApp.php
@@ -27,7 +27,8 @@ class NewProjectApp extends FormRequest
             'provider' => 'required|in:github,bitbucket',
             'repository' => 'required|nullable|regex:_^([a-z-]+)/([a-z-]+)$_i',
             'branch' => 'nullable|string',
-            'config' => 'sometimes|required|array',
+            'config' => 'sometimes|required|array:phpVersion',
+            'config.phpVersion' => 'sometimes|required|regex:/^[7-8]\.[0-4]$/',
         ];
     }
 

--- a/app/Http/Requests/Projects/NewProjectApp.php
+++ b/app/Http/Requests/Projects/NewProjectApp.php
@@ -27,6 +27,7 @@ class NewProjectApp extends FormRequest
             'provider' => 'required|in:github,bitbucket',
             'repository' => 'required|nullable|regex:_^([a-z-]+)/([a-z-]+)$_i',
             'branch' => 'nullable|string',
+            'config' => 'sometimes|required|array',
         ];
     }
 
@@ -41,6 +42,7 @@ class NewProjectApp extends FormRequest
             'source_provider' => $data['provider'],
             'source_repository' => $data['repository'],
             'source_branch' => $data['branch'] ?? '',
+            'config' => $data['config'] ?? [],
         ];
     }
 

--- a/app/Projects/Application.php
+++ b/app/Projects/Application.php
@@ -4,7 +4,7 @@ namespace Servidor\Projects;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -66,7 +66,7 @@ class Application extends Model
     ];
 
     protected $casts = [
-        'config' => AsArrayObject::class,
+        'config' => AsCollection::class,
     ];
 
     protected $dispatchesEvents = [

--- a/app/Projects/Application.php
+++ b/app/Projects/Application.php
@@ -4,6 +4,7 @@ namespace Servidor\Projects;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -64,6 +65,10 @@ class Application extends Model
         'system_user',
     ];
 
+    protected $casts = [
+        'config' => AsArrayObject::class,
+    ];
+
     protected $dispatchesEvents = [
         'saved' => ProjectAppSaved::class,
     ];
@@ -75,6 +80,7 @@ class Application extends Model
         'source_provider',
         'source_repository',
         'source_branch',
+        'config',
     ];
 
     protected $table = 'project_applications';

--- a/database/migrations/2023_01_08_201926_add_config_to_project_applications.php
+++ b/database/migrations/2023_01_08_201926_add_config_to_project_applications.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddConfigToProjectApplications extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('project_applications', static function (Blueprint $table): void {
+            $table->json('config')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('project_applications', static function (Blueprint $table): void {
+            $table->dropColumn('config');
+        });
+    }
+}

--- a/resources/js/components/Projects/Apps/PhpVersions.vue
+++ b/resources/js/components/Projects/Apps/PhpVersions.vue
@@ -1,0 +1,49 @@
+<template>
+    <sui-form @submit.prevent="$emit('next')">
+
+        <sui-form-field :error="'php_version' in errors">
+            <sui-dropdown required selection :options="versions"
+                v-model="version" @input="handleInput">
+                <sui-label basic color="red" pointing v-if="'php_version' in errors">
+                    {{ errors['php_version'][0] }}
+                </sui-label>
+            </sui-dropdown>
+        </sui-form-field>
+
+        <step-buttons @cancel="$emit('cancel')" />
+
+    </sui-form>
+</template>
+
+<script>
+import StepButtons from '../StepButtons';
+
+export default {
+    components: {
+        StepButtons,
+    },
+    props: {
+        errors: { type: Object, default: () => ({}) },
+        value: { type: String, default: '' },
+    },
+    data() {
+        return {
+            version: this.value,
+            versions: [
+                { text: 'PHP 7.0', value: '7.0' },
+                { text: 'PHP 7.1', value: '7.1' },
+                { text: 'PHP 7.2', value: '7.2' },
+                { text: 'PHP 7.3', value: '7.3' },
+                { text: 'PHP 7.4', value: '7.4' },
+                { text: 'PHP 8.0', value: '8.0' },
+                { text: 'PHP 8.1', value: '8.1' },
+            ],
+        };
+    },
+    methods: {
+        handleInput(value) {
+            this.$emit('input', value);
+        },
+    },
+};
+</script>

--- a/resources/js/components/Projects/Viewer/ProjectLogs.vue
+++ b/resources/js/components/Projects/Viewer/ProjectLogs.vue
@@ -1,0 +1,62 @@
+<template>
+
+    <sui-segment attached :inverted="darkMode" v-if="logNames.length">
+
+        <sui-menu pointing secondary :inverted="darkMode">
+            <a is="sui-menu-item" v-for="(title, key) in app.logs" :key="key"
+                :active="activeLog === key" :content="title"
+                @click="viewLog(key)" />
+        </sui-menu>
+
+        <pre>{{ logContent }}</pre>
+
+    </sui-segment>
+
+</template>
+
+<script>
+export default {
+    mounted() {
+        this.initLog();
+    },
+    props: {
+        app: { type: Object, default: () => ({}) },
+        project: { type: Object, default: () => ({}) },
+    },
+    data() {
+        return {
+            activeLog: '',
+            logContent: '',
+        };
+    },
+    computed: {
+        logNames() {
+            return Object.keys(this.app.logs);
+        },
+    },
+    methods: {
+        initLog() {
+            if (this.logNames.length) {
+                this.viewLog(this.logNames[0]);
+            } else {
+                this.logContent = '';
+                this.activeLog = '';
+            }
+        },
+        viewLog(key) {
+            this.logContent = 'Loading...';
+            this.activeLog = key;
+
+            axios
+                .get(`/api/projects/${this.project.id}/logs/${key}.app-${this.app.id}.log`)
+                .then(response => {
+                    this.logContent = '' === response.data.trim()
+                        ? "Log file is empty or doesn't exist."
+                        : response.data;
+                }).catch(() => {
+                    this.logContent = `Failed to load ${this.activeLog} log!`;
+                });
+        },
+    },
+};
+</script>

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -17,6 +17,12 @@
                     @selected="setAppTemplate" />
             </sui-segment>
 
+            <sui-segment v-else-if="step == 'phpver'">
+                <h3 is="sui-header">If your project requires an older PHP, set it here</h3>
+                <php-versions :errors="errors" v-model="defaultApp.config.phpVersion"
+                    @next="nextStep('phpver')" @cancel="cancel" />
+            </sui-segment>
+
             <sui-segment v-else-if="step == 'source'">
                 <h3 is="sui-header">Where are the project files stored?</h3>
                 <source-selector :errors="errors" :providers="providers" v-model="sourceData"
@@ -57,6 +63,7 @@ import ConfirmationForm from '../../components/Projects/ConfirmationForm';
 import ConfirmationText from '../../components/Projects/ConfirmationText';
 import DiscardPrompt from '../../components/Projects/DiscardPrompt.vue';
 import DomainForm from '../../components/Projects/Apps/DomainForm';
+import PhpVersions from '../../components/Projects/Apps/PhpVersions';
 import ProgressModal from '../../components/ProgressModal';
 import RedirectForm from '../../components/Projects/Apps/RedirectForm';
 import SourceSelector from '../../components/Projects/Apps/SourceSelector';
@@ -83,6 +90,7 @@ export default {
         ConfirmationText,
         DiscardPrompt,
         DomainForm,
+        PhpVersions,
         ProgressModal,
         RedirectForm,
         StepList,
@@ -199,6 +207,10 @@ export default {
                     target: '',
                     type: 301,
                 });
+            }
+
+            if (tpl.steps.includes('phpver')) {
+                this.defaultApp.config = { phpVersion: '8.0' };
             }
 
             this.steps.forEach(s => {

--- a/resources/js/pages/Projects/ProjectViewer.vue
+++ b/resources/js/pages/Projects/ProjectViewer.vue
@@ -38,7 +38,14 @@
                             The system user required by this project does not exist!
                         </sui-segment>
 
-                        <sui-header attached="top" :inverted="darkMode">Source Files</sui-header>
+                        <sui-header attached="top" :inverted="darkMode">
+                            <sui-label style="float: right; margin: 0;"
+                                size="tiny" color="violet" title="PHP Version"
+                                v-if="app.config && app.config.phpVersion">
+                                <sui-icon name="php" /> {{ app.config.phpVersion }}
+                            </sui-label>
+                            Source Files
+                        </sui-header>
                         <sui-segment attached :inverted="darkMode">
                             <sui-grid>
                                 <sui-grid-row :columns="2">

--- a/resources/js/pages/Projects/steps.json
+++ b/resources/js/pages/Projects/steps.json
@@ -5,6 +5,12 @@
   "title": "Project Template"
 }, {
   "disabled": true,
+  "errorKeys": ["config.php_version"],
+  "icon": "php",
+  "name": "phpver",
+  "title": "PHP Version"
+}, {
+  "disabled": true,
   "errorKeys": ["repository", "branch"],
   "icon": "code",
   "name": "source",

--- a/resources/js/pages/Projects/templates.json
+++ b/resources/js/pages/Projects/templates.json
@@ -33,13 +33,13 @@
   "colour": "violet",
   "isApp": true,
   "name": "PHP",
-  "steps": ["source", "domain", "confirm"],
+  "steps": ["phpver", "source", "domain", "confirm"],
   "text": "Like HTML projects, but with added support for dynamic PHP content."
 }, {
   "icon": "laravel",
   "colour": "red",
   "isApp": true,
   "name": "Laravel",
-  "steps": ["source", "domain", "confirm"],
+  "steps": ["phpver", "source", "domain", "confirm"],
   "text": "Modified PHP project with hooks for artisan migrations and composer/npm."
 }]

--- a/resources/views/projects/app-templates/php.blade.php
+++ b/resources/views/projects/app-templates/php.blade.php
@@ -14,7 +14,7 @@ server {
         location ~ \.php$ {
             try_files $uri =404;
 
-            fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php{{ $app->config?->get('phpVersion') ?? '8.0' }}-fpm.sock;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 

--- a/tests/Unit/Http/Requests/NewProjectAppTest.php
+++ b/tests/Unit/Http/Requests/NewProjectAppTest.php
@@ -69,4 +69,16 @@ class NewProjectAppTest extends TestCase
         $this->validateFieldFails('repository', true);
         $this->validateFieldFails('repository', ['a', 'b']);
     }
+
+    /** @test */
+    public function config_must_be_an_array(): void
+    {
+        $this->validateFieldPasses('config', ['foo' => 'bar']);
+        $this->validateFieldFails('config', 'foo');
+        $this->validateFieldFails('config', '[]');
+        $this->validateFieldFails('config', true);
+        $this->validateFieldFails('config', null);
+        $this->validateFieldFails('config', []);
+        $this->validateFieldFails('config', '');
+    }
 }

--- a/tests/Unit/Http/Requests/NewProjectAppTest.php
+++ b/tests/Unit/Http/Requests/NewProjectAppTest.php
@@ -73,12 +73,31 @@ class NewProjectAppTest extends TestCase
     /** @test */
     public function config_must_be_an_array(): void
     {
-        $this->validateFieldPasses('config', ['foo' => 'bar']);
+        $this->validateFieldPasses('config', ['phpVersion' => null]);
         $this->validateFieldFails('config', 'foo');
         $this->validateFieldFails('config', '[]');
         $this->validateFieldFails('config', true);
         $this->validateFieldFails('config', null);
         $this->validateFieldFails('config', []);
         $this->validateFieldFails('config', '');
+    }
+
+    /** @test */
+    public function config_php_version_must_be_valid(): void
+    {
+        $this->validateChildFieldPasses('phpVersion', 'config', '7.0', false);
+        $this->validateChildFieldPasses('phpVersion', 'config', '7.1', false);
+        $this->validateChildFieldPasses('phpVersion', 'config', '7.2', false);
+        $this->validateChildFieldPasses('phpVersion', 'config', '7.3', false);
+        $this->validateChildFieldPasses('phpVersion', 'config', '7.4', false);
+        $this->validateChildFieldPasses('phpVersion', 'config', '8.0', false);
+        $this->validateChildFieldPasses('phpVersion', 'config', '8.1', false);
+
+        $this->validateChildFieldFails('phpVersion', 'config', '6.9', false);
+        $this->validateChildFieldFails('phpVersion', 'config', 'foo', false);
+        $this->validateChildFieldFails('phpVersion', 'config', false, false);
+        $this->validateChildFieldFails('phpVersion', 'config', true, false);
+        $this->validateChildFieldFails('phpVersion', 'config', null, false);
+        $this->validateChildFieldFails('phpVersion', 'config', 80, false);
     }
 }

--- a/tests/ValidatesFormRequest.php
+++ b/tests/ValidatesFormRequest.php
@@ -51,28 +51,30 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validateChildField(string $field, string $parent, $value): bool
+    private function validateChildField(string $field, string $parent, $value, bool $nested = true): bool
     {
-        $rule = "{$parent}.*.{$field}";
+        $glue = $nested ? '.*.' : '.';
+        $rule = $parent . $glue . $field;
+        $data = $nested ? [[$field => $value]] : [$field => $value];
 
         return $this->getValidator(
-            [$parent => [[$field => $value]]],
+            [$parent => $data],
             [$rule => $this->rules[$rule]],
         )->passes();
     }
 
-    private function validateChildFieldFails(string $field, string $parent, $value): void
+    private function validateChildFieldFails(string $field, string $parent, $value, bool $nested = true): void
     {
         $this->assertFalse(
-            $this->validateChildField($field, $parent, $value),
+            $this->validateChildField($field, $parent, $value, $nested),
             $this->validationMessage("{$parent}.*.{$field}", $value, 'fail', 'passed'),
         );
     }
 
-    private function validateChildFieldPasses(string $field, string $parent, $value): void
+    private function validateChildFieldPasses(string $field, string $parent, $value, bool $nested = true): void
     {
         $this->assertTrue(
-            $this->validateChildField($field, $parent, $value),
+            $this->validateChildField($field, $parent, $value, $nested),
             $this->validationMessage("{$parent}.*.{$field}", $value, 'pass', 'failed'),
         );
     }


### PR DESCRIPTION
Adds a config field to the `project_applications` table for extra project app data, which enables us to easily add a PHP Version dropdown in the creation wizard.

That option (for PHP/Laravel projects) is then used to set the fpm version in the nginx config, and will be shown in the Project Viewer as a label at the top-right of the source details.