### PR TITLE
Add option for forcing a www-prefix preference

### DIFF
--- a/app/Http/Requests/Projects/NewProjectApp.php
+++ b/app/Http/Requests/Projects/NewProjectApp.php
@@ -33,6 +33,7 @@ class NewProjectApp extends FormRequest
             'config.sslCertificate' => 'sometimes|required|string|filled',
             'config.sslPrivateKey' => 'sometimes|required|string|filled',
             'config.sslRedirect' => 'sometimes|required|boolean',
+            'config.redirectWww' => 'sometimes|required|boolean',
         ];
     }
 

--- a/app/Http/Requests/Projects/NewProjectApp.php
+++ b/app/Http/Requests/Projects/NewProjectApp.php
@@ -27,7 +27,7 @@ class NewProjectApp extends FormRequest
             'provider' => 'required|in:github,bitbucket',
             'repository' => 'required|nullable|regex:_^([a-z-]+)/([a-z-]+)$_i',
             'branch' => 'nullable|string',
-            'config' => 'sometimes|required|array:phpVersion,ssl,sslCertificate,sslPrivateKey,sslRedirect',
+            'config' => 'sometimes|required|array:phpVersion,redirectWww,ssl,sslCertificate,sslPrivateKey,sslRedirect',
             'config.phpVersion' => 'sometimes|required|regex:/^[7-8]\.[0-4]$/',
             'config.ssl' => 'sometimes|required|boolean',
             'config.sslCertificate' => 'sometimes|required|string|filled',

--- a/app/Http/Requests/Projects/NewProjectApp.php
+++ b/app/Http/Requests/Projects/NewProjectApp.php
@@ -33,7 +33,7 @@ class NewProjectApp extends FormRequest
             'config.sslCertificate' => 'sometimes|required|string|filled',
             'config.sslPrivateKey' => 'sometimes|required|string|filled',
             'config.sslRedirect' => 'sometimes|required|boolean',
-            'config.redirectWww' => 'sometimes|required|boolean',
+            'config.redirectWww' => 'sometimes|required|integer|between:-1,1',
         ];
     }
 

--- a/app/Http/Requests/Projects/NewProjectRedirect.php
+++ b/app/Http/Requests/Projects/NewProjectRedirect.php
@@ -11,7 +11,7 @@ class NewProjectRedirect extends FormRequest
     {
         return [
             'domain' => ['required', new Domain()],
-            'config' => 'sometimes|required|array:ssl,sslCertificate,sslPrivateKey,sslRedirect',
+            'config' => 'sometimes|required|array:redirectWww,ssl,sslCertificate,sslPrivateKey,sslRedirect',
             'config.ssl' => 'sometimes|required|boolean',
             'config.sslCertificate' => 'sometimes|required|string|filled',
             'config.sslPrivateKey' => 'sometimes|required|string|filled',

--- a/app/Http/Requests/Projects/NewProjectRedirect.php
+++ b/app/Http/Requests/Projects/NewProjectRedirect.php
@@ -16,7 +16,7 @@ class NewProjectRedirect extends FormRequest
             'config.sslCertificate' => 'sometimes|required|string|filled',
             'config.sslPrivateKey' => 'sometimes|required|string|filled',
             'config.sslRedirect' => 'sometimes|required|boolean',
-            'config.redirectWww' => 'sometimes|required|boolean',
+            'config.redirectWww' => 'sometimes|required|integer|between:-1,1',
             'includeWww' => 'boolean',
             'target' => 'required|string',
             'type' => 'required|integer',

--- a/app/Http/Requests/Projects/NewProjectRedirect.php
+++ b/app/Http/Requests/Projects/NewProjectRedirect.php
@@ -16,6 +16,7 @@ class NewProjectRedirect extends FormRequest
             'config.sslCertificate' => 'sometimes|required|string|filled',
             'config.sslPrivateKey' => 'sometimes|required|string|filled',
             'config.sslRedirect' => 'sometimes|required|boolean',
+            'config.redirectWww' => 'sometimes|required|boolean',
             'includeWww' => 'boolean',
             'target' => 'required|string',
             'type' => 'required|integer',

--- a/resources/js/components/Projects/Apps/DomainForm.vue
+++ b/resources/js/components/Projects/Apps/DomainForm.vue
@@ -19,13 +19,13 @@
         <sui-form-field>
             <label>Prefix Preferences</label>
             <sui-form-fields>
-                <sui-form-field :width="8">
+                <sui-form-field :width="isNotRedirect() ? 8 : 16">
                     <sui-checkbox toggle :checked="value.includeWww"
                         :disabled="value.domain.startsWith('www.')"
                         @change="setValue('includeWww', $event)"
                         label="Handle 'www.' subdomain" />
                 </sui-form-field>
-                <sui-form-field :width="8">
+                <sui-form-field :width="8" v-if="isNotRedirect()">
                     <sui-checkbox toggle :checked="value.config.redirectWww"
                         :disabled="!(value.domain.startsWith('www.') || value.includeWww)"
                         @change="setConfig('redirectWww', $event)"
@@ -57,6 +57,9 @@ export default {
         };
     },
     methods: {
+        isNotRedirect() {
+            return Object.hasOwn(this.value, 'template') && 'archive' !== this.value.template;
+        },
         save() {
             const { value, includeWww } = this;
 

--- a/resources/js/components/Projects/Apps/DomainForm.vue
+++ b/resources/js/components/Projects/Apps/DomainForm.vue
@@ -5,9 +5,9 @@
 
             <label>Domain name</label>
 
-            <sui-input :value="value"
+            <sui-input :value="value.domain"
                 placeholder="example.com" required
-                @input="$emit('input', $event)" />
+                @input="setValue('domain', $event)" />
 
             <sui-label basic color="red" pointing
                 v-if="'domain' in errors">
@@ -20,13 +20,15 @@
             <label>Prefix Preferences</label>
             <sui-form-fields>
                 <sui-form-field :width="8">
-                    <sui-checkbox toggle v-model="includeWww"
-                        :disabled="this.value.startsWith('www.')"
+                    <sui-checkbox toggle :checked="value.includeWww"
+                        :disabled="value.domain.startsWith('www.')"
+                        @change="setValue('includeWww', $event)"
                         label="Handle 'www.' subdomain" />
                 </sui-form-field>
                 <sui-form-field :width="8">
-                    <sui-checkbox toggle v-model="redirectWww"
-                        :disabled="this.value.startsWith('www.') || !this.includeWww"
+                    <sui-checkbox toggle :checked="value.config.redirectWww"
+                        :disabled="!(value.domain.startsWith('www.') || value.includeWww)"
+                        @change="setConfig('redirectWww', $event)"
                         label="Auto-remove 'www.' prefix" />
                 </sui-form-field>
             </sui-form-fields>
@@ -46,7 +48,7 @@ export default {
     },
     props: {
         errors: { type: Object, default: () => ({}) },
-        value: { type: String, default: '' },
+        value: { type: Object, default: () => ({}) },
     },
     data() {
         return {
@@ -59,6 +61,12 @@ export default {
             const { value, includeWww } = this;
 
             this.$emit('next', { includeWww, domain: value });
+        },
+        setConfig(key, value) {
+            this.setValue('config', { ...this.value.config, [key]: value });
+        },
+        setValue(key, value) {
+            this.$emit('input', { ...this.value, [key]: value });
         },
     },
 };

--- a/resources/js/components/Projects/Apps/DomainForm.vue
+++ b/resources/js/components/Projects/Apps/DomainForm.vue
@@ -18,18 +18,17 @@
 
         <sui-form-field>
             <label>Prefix Preferences</label>
-            <sui-form-fields>
+            <sui-form-fields inline>
                 <sui-form-field :width="isNotRedirect() ? 8 : 16">
                     <sui-checkbox toggle :checked="value.includeWww"
                         :disabled="value.domain.startsWith('www.')"
                         @change="setValue('includeWww', $event)"
                         label="Handle 'www.' subdomain" />
                 </sui-form-field>
-                <sui-form-field :width="8" v-if="isNotRedirect()">
-                    <sui-checkbox toggle :checked="value.config.redirectWww"
+                <sui-form-field :width="8" v-if="isNotRedirect()" style="display: block">
+                    <sui-dropdown :options="redirectOptions" :value="value.config.redirectWww"
                         :disabled="!(value.domain.startsWith('www.') || value.includeWww)"
-                        @change="setConfig('redirectWww', $event)"
-                        label="Auto-remove 'www.' prefix" />
+                        fluid selection @input="setConfig('redirectWww', $event)" />
                 </sui-form-field>
             </sui-form-fields>
         </sui-form-field>
@@ -52,8 +51,11 @@ export default {
     },
     data() {
         return {
-            includeWww: false,
-            redirectWww: true,
+            redirectOptions: [
+                { text: 'Serve both (no preference)', value: 0 },
+                { text: 'Redirect www → non-www', value: 1 },
+                { text: 'Redirect non-www → www', value: -1 },
+            ],
         };
     },
     methods: {

--- a/resources/js/components/Projects/Apps/DomainForm.vue
+++ b/resources/js/components/Projects/Apps/DomainForm.vue
@@ -17,9 +17,19 @@
         </sui-form-field>
 
         <sui-form-field>
-            <sui-checkbox toggle v-model="includeWww"
-                :disabled="this.value.startsWith('www.')"
-                label="Include 'www.' subdomain" />
+            <label>Prefix Preferences</label>
+            <sui-form-fields>
+                <sui-form-field :width="8">
+                    <sui-checkbox toggle v-model="includeWww"
+                        :disabled="this.value.startsWith('www.')"
+                        label="Handle 'www.' subdomain" />
+                </sui-form-field>
+                <sui-form-field :width="8">
+                    <sui-checkbox toggle v-model="redirectWww"
+                        :disabled="this.value.startsWith('www.') || !this.includeWww"
+                        label="Auto-remove 'www.' prefix" />
+                </sui-form-field>
+            </sui-form-fields>
         </sui-form-field>
 
         <step-buttons @cancel="$emit('cancel')" />
@@ -41,6 +51,7 @@ export default {
     data() {
         return {
             includeWww: false,
+            redirectWww: true,
         };
     },
     methods: {

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -31,8 +31,11 @@
 
             <sui-segment v-else-if="step == 'domain'">
                 <h3 is="sui-header">Set the main entry point for your app</h3>
-                <domain-form :errors="errors" v-model="defaultApp.domain"
-                    @next="setDomain" @cancel="cancel" />
+                <domain-form :errors="errors" v-model="defaultRedirect"
+                    @next="nextStep('domain')" @cancel="cancel"
+                    v-if="defaultApp.template == 'archive'" />
+                <domain-form :errors="errors" v-model="defaultApp" v-else
+                    @next="nextStep('domain')" @cancel="cancel" />
             </sui-segment>
 
             <sui-segment v-else-if="step == 'ssl'">

--- a/resources/views/projects/app-templates/basic.blade.php
+++ b/resources/views/projects/app-templates/basic.blade.php
@@ -1,8 +1,24 @@
+@if ($app->include_www && $app->config?->get('redirectWww'))
+server {
+@if ($app->config?->get('ssl'))
+    listen 80;
+    listen 443;
+
+    ssl_certificate {{ $app->config?->get('sslCertificate') }};
+    ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
+
+@endif
+    server_name www.{{ $app->domain_name }};
+
+    return 301 http{{ $app->config?->get('ssl') ? 's' : '' }}://{{ $app->domain_name }};
+}
+
+@endif
 @if ($app->config?->get('ssl') && $app->config?->get('sslRedirect'))
 server {
     listen 80;
 
-@if ($app->include_www)
+@if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
 @else
     server_name {{ $app->domain_name }};
@@ -23,7 +39,7 @@ server {
     ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
 @endif
 
-@if ($app->include_www)
+@if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
 @else
     server_name {{ $app->domain_name }};

--- a/resources/views/projects/app-templates/basic.blade.php
+++ b/resources/views/projects/app-templates/basic.blade.php
@@ -1,4 +1,4 @@
-@if ($app->include_www && $app->config?->get('redirectWww'))
+@if ($app->config?->get('redirectWww'))
 server {
 @if ($app->config?->get('ssl'))
     listen 80;
@@ -8,9 +8,15 @@ server {
     ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
 
 @endif
+@if (1 === $app->config?->get('redirectWww'))
     server_name www.{{ $app->domain_name }};
 
     return 301 http{{ $app->config?->get('ssl') ? 's' : '' }}://{{ $app->domain_name }};
+@else
+    server_name {{ $app->domain_name }};
+
+    return 301 http{{ $app->config?->get('ssl') ? 's' : '' }}://www.{{ $app->domain_name }};
+@endif
 }
 
 @endif
@@ -41,6 +47,8 @@ server {
 
 @if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
+@elseif ($app->include_www && 0 > $app->config?->get('redirectWww'))
+    server_name www.{{ $app->domain_name }};
 @else
     server_name {{ $app->domain_name }};
 @endif

--- a/resources/views/projects/app-templates/basic.blade.php
+++ b/resources/views/projects/app-templates/basic.blade.php
@@ -43,8 +43,8 @@ server {
 
     ssl_certificate {{ $app->config?->get('sslCertificate') }};
     ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
-@endif
 
+@endif
 @if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
 @elseif ($app->include_www && 0 > $app->config?->get('redirectWww'))

--- a/resources/views/projects/app-templates/php.blade.php
+++ b/resources/views/projects/app-templates/php.blade.php
@@ -1,8 +1,24 @@
+@if ($app->include_www && $app->config?->get('redirectWww'))
+server {
+@if ($app->config?->get('ssl'))
+    listen 80;
+    listen 443;
+
+    ssl_certificate {{ $app->config?->get('sslCertificate') }};
+    ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
+
+@endif
+    server_name www.{{ $app->domain_name }};
+
+    return 301 http{{ $app->config?->get('ssl') ? 's' : '' }}://{{ $app->domain_name }};
+}
+
+@endif
 @if ($app->config?->get('ssl') && $app->config?->get('sslRedirect'))
 server {
     listen 80;
 
-@if ($app->include_www)
+@if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
 @else
     server_name {{ $app->domain_name }};
@@ -23,7 +39,7 @@ server {
     ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
 @endif
 
-@if ($app->include_www)
+@if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
 @else
     server_name {{ $app->domain_name }};

--- a/resources/views/projects/app-templates/php.blade.php
+++ b/resources/views/projects/app-templates/php.blade.php
@@ -1,4 +1,4 @@
-@if ($app->include_www && $app->config?->get('redirectWww'))
+@if ($app->config?->get('redirectWww'))
 server {
 @if ($app->config?->get('ssl'))
     listen 80;
@@ -8,9 +8,15 @@ server {
     ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
 
 @endif
+@if (1 === $app->config?->get('redirectWww'))
     server_name www.{{ $app->domain_name }};
 
     return 301 http{{ $app->config?->get('ssl') ? 's' : '' }}://{{ $app->domain_name }};
+@else
+    server_name {{ $app->domain_name }};
+
+    return 301 http{{ $app->config?->get('ssl') ? 's' : '' }}://www.{{ $app->domain_name }};
+@endif
 }
 
 @endif
@@ -41,6 +47,8 @@ server {
 
 @if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
+@elseif ($app->include_www && 0 > $app->config?->get('redirectWww'))
+    server_name www.{{ $app->domain_name }};
 @else
     server_name {{ $app->domain_name }};
 @endif

--- a/resources/views/projects/app-templates/php.blade.php
+++ b/resources/views/projects/app-templates/php.blade.php
@@ -43,8 +43,8 @@ server {
 
     ssl_certificate {{ $app->config?->get('sslCertificate') }};
     ssl_certificate_key {{ $app->config?->get('sslPrivateKey') }};
-@endif
 
+@endif
 @if ($app->include_www && !$app->config?->get('redirectWww'))
     server_name {{ $app->domain_name }} www.{{ $app->domain_name }};
 @elseif ($app->include_www && 0 > $app->config?->get('redirectWww'))

--- a/tests/Feature/Api/Projects/Applications/NginxConfigGenerationTest.php
+++ b/tests/Feature/Api/Projects/Applications/NginxConfigGenerationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Api\Projects\Applications;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Servidor\Projects\Project;
+use Tests\RequiresAuth;
+use Tests\TestCase;
+
+class NginxConfigGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+    use RequiresAuth;
+
+    /**
+     * @test
+     *
+     * @dataProvider configs
+     */
+    public function generates_valid_nginx_configs(string $tpl, bool $www, int $redirect, string $conf): void
+    {
+        $project = Project::create(['name' => 'Config Test']);
+        $path = storage_path('app/vhosts/nginx.test.conf');
+
+        $response = $this->authed()->postJson('/api/projects/' . $project->id . '/apps', [
+            'repository' => 'dshoreman/servidor-test-site',
+            'domain' => 'nginx.test',
+            'provider' => 'github',
+            'branch' => 'develop',
+            'includeWww' => $www,
+            'template' => $tpl,
+            'config' => [
+                'redirectWww' => $redirect,
+            ],
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertFileExists($path);
+        $this->assertFileEquals('tests/Feature/Api/Projects/nginx-configs/' . $conf, $path);
+    }
+
+    public function configs(): array
+    {
+        return [
+            ['html', false, 0, 'basic.nossl.no-www.conf'],
+            ['html', true, 0, 'basic.nossl.any-www.conf'],
+            ['php', false, 0, 'php.nossl.no-www.conf'],
+            ['php', true, 0, 'php.nossl.any-www.conf'],
+            ['php', true, 1, 'php.nossl.strip-www.conf'],
+            ['php', true, -1, 'php.nossl.force-www.conf'],
+        ];
+    }
+}

--- a/tests/Feature/Api/Projects/nginx-configs/basic.nossl.any-www.conf
+++ b/tests/Feature/Api/Projects/nginx-configs/basic.nossl.any-www.conf
@@ -1,0 +1,10 @@
+server {
+    server_name nginx.test www.nginx.test;
+
+    root /var/www/config-test/servidor-test-site;
+    index index.html index.htm;
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/tests/Feature/Api/Projects/nginx-configs/basic.nossl.no-www.conf
+++ b/tests/Feature/Api/Projects/nginx-configs/basic.nossl.no-www.conf
@@ -1,0 +1,10 @@
+server {
+    server_name nginx.test;
+
+    root /var/www/config-test/servidor-test-site;
+    index index.html index.htm;
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/tests/Feature/Api/Projects/nginx-configs/php.nossl.any-www.conf
+++ b/tests/Feature/Api/Projects/nginx-configs/php.nossl.any-www.conf
@@ -1,0 +1,24 @@
+server {
+    server_name nginx.test www.nginx.test;
+
+    root /home/config-test/servidor-test-site;
+    index index.php index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.php?query_string;
+
+        location ~ \.php$ {
+            try_files $uri =404;
+
+            fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+            include fastcgi_params;
+        }
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/tests/Feature/Api/Projects/nginx-configs/php.nossl.force-www.conf
+++ b/tests/Feature/Api/Projects/nginx-configs/php.nossl.force-www.conf
@@ -1,0 +1,30 @@
+server {
+    server_name nginx.test;
+
+    return 301 http://www.nginx.test;
+}
+
+server {
+    server_name www.nginx.test;
+
+    root /home/config-test/servidor-test-site;
+    index index.php index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.php?query_string;
+
+        location ~ \.php$ {
+            try_files $uri =404;
+
+            fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+            include fastcgi_params;
+        }
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/tests/Feature/Api/Projects/nginx-configs/php.nossl.no-www.conf
+++ b/tests/Feature/Api/Projects/nginx-configs/php.nossl.no-www.conf
@@ -1,0 +1,24 @@
+server {
+    server_name nginx.test;
+
+    root /home/config-test/servidor-test-site;
+    index index.php index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.php?query_string;
+
+        location ~ \.php$ {
+            try_files $uri =404;
+
+            fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+            include fastcgi_params;
+        }
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/tests/Feature/Api/Projects/nginx-configs/php.nossl.strip-www.conf
+++ b/tests/Feature/Api/Projects/nginx-configs/php.nossl.strip-www.conf
@@ -1,0 +1,30 @@
+server {
+    server_name www.nginx.test;
+
+    return 301 http://nginx.test;
+}
+
+server {
+    server_name nginx.test;
+
+    root /home/config-test/servidor-test-site;
+    index index.php index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.php?query_string;
+
+        location ~ \.php$ {
+            try_files $uri =404;
+
+            fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+            include fastcgi_params;
+        }
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}


### PR DESCRIPTION
Adds a new dropdown to the domain form where a user can define whether the domain should have the "www." forced, removed, or "prefix agnostic".

Also adds a test to make sure the generated configs are as we'd actually expect, although there aren't any for SSL sites so that's one thing that could be improved in future if there are ever any issues with it.