### PR TITLE
Fix steps not being added on project creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           command: make test-for-ci
-          timeout_minutes: 2
+          timeout_minutes: 3
           max_attempts: 3
           retry_on: error
       - name: Upload coverage results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * [projects] PHP version can now be set when creating a project
 * [projects] Added support for enabling HTTPS and setting SSL certificates
+* [projects] The presence or absence of the 'www.' can now optionally be forced
+
+### Changed
+* [projects] App/redirect creation steps are now added together
 
 ### Fixed
 * [projects] The logs header is now correctly displayed when there are logs
 * [projects] Values on the Creation form no longer fail to reset when navigating away
+* [projects] Missing steps when saving project apps are now correctly added
+* [projects] Progress bar no longer jumps around somewhat eratically during creation
 
 
 ## [0.15.3] - 2023-01-08

--- a/app/Projects/Applications/ApplyAppNginxConfig.php
+++ b/app/Projects/Applications/ApplyAppNginxConfig.php
@@ -15,7 +15,7 @@ class ApplyAppNginxConfig
         $project = $event->getProject();
 
         $step = new ProgressStep('nginx.save', 'Saving nginx config', 50);
-        ProjectProgress::dispatch($project, $step);
+        ProjectProgress::dispatch($project, $step->start());
 
         try {
             (new SyncNginxConfig($app))->execute();

--- a/app/Projects/Applications/CreateSystemUser.php
+++ b/app/Projects/Applications/CreateSystemUser.php
@@ -17,7 +17,7 @@ class CreateSystemUser
         $project = $event->getProject();
 
         $step = new ProgressStep('user.create', 'Creating system user', 35);
-        ProjectProgress::dispatch($project, $step);
+        ProjectProgress::dispatch($project, $step->start());
         $reason = $this->shouldPreventCreation($app);
 
         if (\is_string($reason)) {

--- a/app/Projects/Applications/DeployApp.php
+++ b/app/Projects/Applications/DeployApp.php
@@ -15,7 +15,7 @@ class DeployApp
         $project = $event->getProject();
 
         $step = new ProgressStep('clone', 'Cloning project files', 85);
-        ProjectProgress::dispatch($project, $step);
+        ProjectProgress::dispatch($project, $step->start());
 
         if (!$project->is_enabled) {
             ProjectProgress::dispatch($project, $step->skip(ProgressStep::REASON_NOT_ENABLED));

--- a/app/Projects/Applications/PrepareSsl.php
+++ b/app/Projects/Applications/PrepareSsl.php
@@ -13,7 +13,7 @@ class PrepareSsl
     {
         $project = $event->getProject();
 
-        $step = new ProgressStep('nginx.ssl', 'Saving SSL certificate', 40);
+        $step = new ProgressStep('nginx.ssl', 'Saving SSL certificate', 20);
         ProjectProgress::dispatch($project, $step->start());
 
         try {

--- a/app/Projects/CalculateSteps.php
+++ b/app/Projects/CalculateSteps.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Servidor\Projects;
+
+use Servidor\Projects\Applications\ProjectAppSaving;
+use Servidor\Projects\Redirects\ProjectRedirectSaving;
+
+class CalculateSteps
+{
+    public const STEPS = [
+        'clone' => 'Cloning project files',
+        'enable' => 'Enabling project',
+        'nginx.reload' => 'Reloading nginx service',
+        'nginx.save' => 'Saving nginx config',
+        'nginx.ssl' => 'Saving SSL certificate',
+        'user.create' => 'Creating system user',
+    ];
+
+    private ?Project $project = null;
+
+    public function handle(ProjectAppSaving|ProjectRedirectSaving $event): void
+    {
+        $this->project = $event->getProject();
+
+        if ($event instanceof ProjectAppSaving) {
+            $this->triggerAppEvents();
+        }
+
+        if ($event instanceof ProjectRedirectSaving) {
+            $this->triggerRedirectEvents();
+        }
+    }
+
+    private function triggerAppEvents(): void
+    {
+        $this->trigger('nginx.ssl');
+        $this->trigger('user.create');
+        $this->trigger('nginx.save');
+        $this->trigger('clone');
+        $this->trigger('enable', 'Enabling application');
+        $this->trigger('nginx.reload');
+    }
+
+    private function triggerRedirectEvents(): void
+    {
+        $this->trigger('nginx.ssl');
+        $this->trigger('nginx.save');
+        $this->trigger('enable', 'Enabling redirect');
+        $this->trigger('nginx.reload');
+    }
+
+    private function trigger(string $key, string $text = ''): void
+    {
+        ProjectProgress::dispatch(
+            $this->project,
+            new ProgressStep($key, $text ?: self::STEPS[$key], 0),
+        );
+    }
+}

--- a/app/Projects/ReloadNginxService.php
+++ b/app/Projects/ReloadNginxService.php
@@ -13,7 +13,7 @@ class ReloadNginxService
     public function handle($event): void
     {
         $step = new ProgressStep('nginx.reload', 'Reloading nginx service', 100);
-        ProjectProgress::dispatch($event->getProject(), $step);
+        ProjectProgress::dispatch($event->getProject(), $step->start());
 
         exec('sudo systemctl reload-or-restart nginx.service');
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -11,13 +11,13 @@ use Servidor\Projects\Applications\DeployApp;
 use Servidor\Projects\Applications\PrepareSsl;
 use Servidor\Projects\Applications\ProjectAppSaved;
 use Servidor\Projects\Applications\ProjectAppSaving;
+use Servidor\Projects\CalculateSteps;
 use Servidor\Projects\ProjectSaved;
 use Servidor\Projects\Redirects\ApplyRedirectNginxConfig;
 use Servidor\Projects\Redirects\PrepareRedirectSsl;
 use Servidor\Projects\Redirects\ProjectRedirectSaved;
 use Servidor\Projects\Redirects\ProjectRedirectSaving;
 use Servidor\Projects\ReloadNginxService;
-use Servidor\Projects\CalculateSteps;
 use Servidor\Projects\ToggleProjectVisibility;
 
 class EventServiceProvider extends ServiceProvider

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -17,6 +17,7 @@ use Servidor\Projects\Redirects\PrepareRedirectSsl;
 use Servidor\Projects\Redirects\ProjectRedirectSaved;
 use Servidor\Projects\Redirects\ProjectRedirectSaving;
 use Servidor\Projects\ReloadNginxService;
+use Servidor\Projects\CalculateSteps;
 use Servidor\Projects\ToggleProjectVisibility;
 
 class EventServiceProvider extends ServiceProvider
@@ -27,6 +28,7 @@ class EventServiceProvider extends ServiceProvider
             ReloadNginxService::class,
         ],
         ProjectAppSaving::class => [
+            CalculateSteps::class,
             PrepareSsl::class,
         ],
         ProjectAppSaved::class => [
@@ -37,6 +39,7 @@ class EventServiceProvider extends ServiceProvider
             ReloadNginxService::class,
         ],
         ProjectRedirectSaving::class => [
+            CalculateSteps::class,
             PrepareRedirectSsl::class,
         ],
         ProjectRedirectSaved::class => [

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -241,15 +241,6 @@ export default {
 
             this.nextStep('source');
         },
-        setDomain(values) {
-            if ('archive' === this.defaultApp.template) {
-                this.defaultRedirect = { ...this.defaultRedirect, ...values };
-            } else {
-                this.defaultApp = { ...this.defaultApp, ...values };
-            }
-
-            this.nextStep('domain');
-        },
         setRedirect(redirect) {
             this.defaultRedirect = { ...this.defaultRedirect, ...redirect };
 

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -86,8 +86,8 @@ import providers from './source-providers.json';
 import steps from './steps.json';
 import templates from './templates.json';
 
-const PERCENT_APP = 25,
-    PERCENT_REDIRECT = 40,
+const PERCENT_APP = 95,
+    PERCENT_REDIRECT = 95,
     STEP_APP = 'app.save',
     STEP_CREATE = 'project.create',
     STEP_REDIRECT = 'redirect.save',
@@ -312,7 +312,7 @@ export default {
                 ? ['createApp', { app: this.project.applications[0] }, PERCENT_APP]
                 : ['createRedirect', { redirect: this.project.redirects[0] }, PERCENT_REDIRECT];
 
-            await this.$store.dispatch('progress/start', { step });
+            await this.$store.dispatch('progress/stepStarted', { step });
             await this.$store.dispatch(`projects/${action}`, { projectId: project.id, ...data });
             await this.$store.dispatch('progress/stepCompleted', { step, progress });
         },

--- a/resources/js/store/modules/Progress.js
+++ b/resources/js/store/modules/Progress.js
@@ -8,7 +8,7 @@ export default {
         title: 'Loading...',
     },
     mutations: {
-        addStep: (state, { name, text, status }) => {
+        addStep: (state, { name, text }) => {
             state.steps.push({ name,
                 text,
                 icon: 'minus disabled',

--- a/resources/js/store/modules/Progress.js
+++ b/resources/js/store/modules/Progress.js
@@ -65,7 +65,7 @@ export default {
                         dispatch('stepSkipped', data);
                         break;
                     case 'working':
-                        dispatch('stepProgressed', data);
+                        dispatch('stepStarted', data);
                         break;
                     case 'complete':
                         dispatch('stepCompleted', data);
@@ -78,20 +78,17 @@ export default {
         progress: ({ commit }, { progress }) => {
             commit('setProgress', progress);
         },
-        start: ({ commit }, { step }) => {
-            commit('setIcon', { step, icon: 'loading spinner' });
-        },
-        stepCompleted({ commit }, { step, progress = 0 }) {
-            if (0 < progress) {
+        stepCompleted({ commit, state }, { step, progress = 0 }) {
+            const maxdiff = 40;
+
+            // Prevents an issue where config reload sets 100% progress too soon
+            if (0 < progress && progress < maxdiff + state.percentComplete) {
                 commit('setProgress', progress);
             }
             commit('setIcon', { step, icon: 'check', colour: 'green' });
         },
-        stepProgressed({ commit }, { step, progress = 0 }) {
-            if (0 < progress) {
-                commit('setProgress', progress);
-            }
-            commit('setIcon', { step, icon: 'loading spinner', colour: 'purple' });
+        stepStarted({ commit }, { step }) {
+            commit('setIcon', { step, icon: 'loading spinner' });
         },
         stepSkipped({ commit }, { step, progress = 0 }) {
             if (0 < progress) {


### PR DESCRIPTION
When saving a new project with an application of some sort (not a
redirect), many of the events won't have their step added despite the
event itself still being sent through Pusher.

This updates the affected "jobs" to trigger the start progress event,
which gives the progress modal a bit of a kick up the rear, and also
updates modal to show steps sooner and with more reliable progress.