### PR TITLE
Fix issue where projects can't be deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [projects] Values on the Creation form no longer fail to reset when navigating away
 * [projects] Missing steps when saving project apps are now correctly added
 * [projects] Progress bar no longer jumps around somewhat eratically during creation
+* [projects] Deleting a project is now possible even when it has a service attached
 
 
 ## [0.15.3] - 2023-01-08

--- a/database/migrations/2023_02_15_164426_merge_applications_and_redirects_to_services_table.php
+++ b/database/migrations/2023_02_15_164426_merge_applications_and_redirects_to_services_table.php
@@ -14,6 +14,13 @@ class MergeApplicationsAndRedirectsToServicesTable extends Migration
                 'source_provider',
                 'source_repository',
             ]);
+
+            $table->dropForeign(['project_id']);
+            $table->foreign('project_id')
+                ->references('id')
+                ->on('projects')
+                ->onDelete('cascade')
+            ;
         });
 
         Schema::rename('project_applications', 'project_services');
@@ -28,6 +35,9 @@ class MergeApplicationsAndRedirectsToServicesTable extends Migration
             $table->string('source_provider')->default('');
             $table->string('source_repository')->default('');
             $table->string('source_branch')->default('');
+
+            $table->dropForeign(['project_id']);
+            $table->foreign('project_id')->references('id')->on('projects');
         });
 
         Schema::create('project_redirects', static function (Blueprint $table): void {

--- a/tests/Feature/Api/Projects/RemoveProjectTest.php
+++ b/tests/Feature/Api/Projects/RemoveProjectTest.php
@@ -6,6 +6,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Response;
 use Servidor\Projects\Project;
+use Servidor\Projects\ProjectService;
 use Tests\RequiresAuth;
 use Tests\TestCase;
 
@@ -41,5 +42,20 @@ class RemoveProjectTest extends TestCase
 
         $response->assertStatus(Response::HTTP_NO_CONTENT);
         $this->assertNull(Project::find($project->id));
+    }
+
+    /** @test */
+    public function project_with_service_can_still_be_deleted(): void
+    {
+        $project = Project::create(['name' => 'Delete me again!']);
+        $service = $project->services()->create([
+            'template' => 'html',
+        ]);
+
+        $response = $this->authed()->deleteJson('/api/projects/' . $project->id);
+
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+        $this->assertNull(Project::find($project->id));
+        $this->assertNull(ProjectService::find($service->id));
     }
 }


### PR DESCRIPTION
Adds `ON DELETE CASCADE` to the foreign key constraint so that projects no longer trigger an error when you try to delete one with an app.