### PR TITLE
Add basic Account Settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* [accounts] Name, login email and password can now be changed from the User menu
 * [projects] PHP version can now be set when creating a project
 * [projects] Added support for enabling HTTPS and setting SSL certificates
 * [projects] The presence or absence of the 'www.' can now optionally be forced

--- a/app/Http/Controllers/User/UpdateAccount.php
+++ b/app/Http/Controllers/User/UpdateAccount.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Servidor\Http\Controllers\User;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Servidor\Http\Controllers\Controller;
+use Servidor\User;
+
+class UpdateAccount extends Controller
+{
+    use RefreshDatabase;
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        \assert($user instanceof User);
+
+        $user->updateOrFail((array) $request->input());
+
+        return response()->json($user);
+    }
+}

--- a/app/Http/Controllers/User/UpdateAccount.php
+++ b/app/Http/Controllers/User/UpdateAccount.php
@@ -5,6 +5,7 @@ namespace Servidor\Http\Controllers\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Servidor\Http\Controllers\Controller;
 use Servidor\User;
 
@@ -17,10 +18,19 @@ class UpdateAccount extends Controller
         $user = $request->user();
         \assert($user instanceof User);
 
-        $user->updateOrFail($request->validate([
-            'name' => 'string',
-            'email' => 'email',
-        ]));
+        $data = $request->validate([
+            'name' => ['string'],
+            'email' => ['email', 'prohibits:newPassword'],
+            'password' => ['current_password', 'required_with:newPassword'],
+            'newPassword' => ['string', 'min:8', 'confirmed', 'required_with:password'],
+            'newPassword_confirmation' => ['same:newPassword', 'required_with:newPassword'],
+        ]);
+
+        if (isset($data['newPassword'])) {
+            $data['password'] = Hash::make((string) $data['newPassword']);
+        }
+
+        $user->updateOrFail($data);
 
         return response()->json($user);
     }

--- a/app/Http/Controllers/User/UpdateAccount.php
+++ b/app/Http/Controllers/User/UpdateAccount.php
@@ -17,7 +17,10 @@ class UpdateAccount extends Controller
         $user = $request->user();
         \assert($user instanceof User);
 
-        $user->updateOrFail((array) $request->input());
+        $user->updateOrFail($request->validate([
+            'name' => 'string',
+            'email' => 'email',
+        ]));
 
         return response()->json($user);
     }

--- a/resources/js/components/Projects/Services/DomainForm.vue
+++ b/resources/js/components/Projects/Services/DomainForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="save()" v>
+    <sui-form @submit.prevent="save()">
 
         <sui-form-field :error="'domain' in errors">
 

--- a/resources/js/layouts/Servidor.vue
+++ b/resources/js/layouts/Servidor.vue
@@ -30,6 +30,9 @@
                 <a is="sui-menu-item">
                     {{ user.name }} <sui-icon name="chevron up" />
                 </a>
+                <router-link is="sui-menu-item" :to="{ name: 'account' }">
+                    Account Settings
+                </router-link>
                 <a is="sui-menu-item" @click.prevent="logout">
                     Logout
                 </a>

--- a/resources/js/pages/Auth/AccountEditor.vue
+++ b/resources/js/pages/Auth/AccountEditor.vue
@@ -94,6 +94,7 @@ export default {
 
             try {
                 await this.$store.dispatch('updateAccount', { name, email });
+                this.data = {};
             } catch (error) {
                 this.errors = error.response.data.errors;
             }

--- a/resources/js/pages/Auth/AccountEditor.vue
+++ b/resources/js/pages/Auth/AccountEditor.vue
@@ -31,31 +31,31 @@
             </sui-segment>
 
             <sui-segment>
-                <sui-form>
-                    <sui-form-field>
+                <sui-form @submit.prevent="changePassword()">
+                    <sui-form-field :error="'password' in errors">
                         <label>Current Password</label>
                         <sui-input required type="password" v-model="data.currentPassword" />
-                        <sui-label basic color="red" pointing
-                            v-if="'currentPassword' in errors">
-                            {{ errors['currentPassword'][0] }}
-                        </sui-label>
-                    </sui-form-field>
-
-                    <sui-form-field>
-                        <label>New Password</label>
-                        <sui-input required type="password" v-model="data.password" />
                         <sui-label basic color="red" pointing
                             v-if="'password' in errors">
                             {{ errors['password'][0] }}
                         </sui-label>
                     </sui-form-field>
 
-                    <sui-form-field>
+                    <sui-form-field :error="'newPassword' in errors">
+                        <label>New Password</label>
+                        <sui-input required type="password" v-model="data.newPassword" />
+                        <sui-label basic color="red" pointing
+                            v-if="'newPassword' in errors">
+                            {{ errors['newPassword'][0] }}
+                        </sui-label>
+                    </sui-form-field>
+
+                    <sui-form-field :error="'newPassword_confirmation' in errors">
                         <label>Confirm New Password</label>
                         <sui-input required type="password" v-model="data.confirmPassword" />
                         <sui-label basic color="red" pointing
-                            v-if="'confirmPassword' in errors">
-                            {{ errors['confirmPassword'][0] }}
+                            v-if="'newPassword_confirmation' in errors">
+                            {{ errors['newPassword_confirmation'][0] }}
                         </sui-label>
                     </sui-form-field>
 
@@ -93,9 +93,18 @@ export default {
             try {
                 await this.$store.dispatch('updateAccount', { name, email });
             } catch (error) {
-                const { response: res } = error;
-
-                this.errors = res.data.errors;
+                this.errors = error.response.data.errors;
+            }
+        },
+        async changePassword() {
+            try {
+                await this.$store.dispatch('updateAccount', {
+                    password: this.data.currentPassword,
+                    newPassword: this.data.newPassword,
+                    newPassword_confirmation: this.data.confirmPassword,
+                });
+            } catch (error) {
+                this.errors = error.response.data.errors;
             }
         },
     },

--- a/resources/js/pages/Auth/AccountEditor.vue
+++ b/resources/js/pages/Auth/AccountEditor.vue
@@ -1,0 +1,85 @@
+<template>
+    <sui-grid container>
+        <sui-grid-column>
+            <sui-form @submit.prevent="save()">
+                <h2>Account Settings</h2>
+
+                <sui-segment>
+                    <sui-form-field :error="'name' in errors">
+                        <label>Account Name</label>
+                        <sui-input required v-model="data.name"
+                            :placeholder="user.name" />
+                        <sui-label basic color="red" pointing
+                            v-if="'name' in errors">
+                            {{ errors['name'][0] }}
+                        </sui-label>
+                    </sui-form-field>
+
+                    <sui-form-field :error="'email' in errors">
+                        <label>Email Address</label>
+                        <sui-input required type="email" v-model="data.email"
+                            :placeholder="user.email" />
+                        <sui-label basic color="red" pointing
+                            v-if="'email' in errors">
+                            {{ errors['email'][0] }}
+                        </sui-label>
+                    </sui-form-field>
+                </sui-segment>
+
+                <sui-segment>
+                    <sui-form-field>
+                        <label>Current Password</label>
+                        <sui-input required type="password" v-model="data.currentPassword" />
+                        <sui-label basic color="red" pointing
+                            v-if="'currentPassword' in errors">
+                            {{ errors['currentPassword'][0] }}
+                        </sui-label>
+                    </sui-form-field>
+
+                    <sui-form-field>
+                        <label>New Password</label>
+                        <sui-input required type="password" v-model="data.password" />
+                        <sui-label basic color="red" pointing
+                            v-if="'password' in errors">
+                            {{ errors['password'][0] }}
+                        </sui-label>
+                    </sui-form-field>
+
+                    <sui-form-field>
+                        <label>Confirm New Password</label>
+                        <sui-input required type="password" v-model="data.confirmPassword" />
+                        <sui-label basic color="red" pointing
+                            v-if="'confirmPassword' in errors">
+                            {{ errors['confirmPassword'][0] }}
+                        </sui-label>
+                    </sui-form-field>
+                </sui-segment>
+
+                <sui-button primary floated="right"
+                            content="Save changes" />
+
+            </sui-form>
+        </sui-grid-column>
+    </sui-grid>
+</template>
+
+<script>
+import { mapGetters, mapState } from 'vuex';
+
+export default {
+    data() {
+        return {
+            data: {},
+            errors: {},
+        };
+    },
+    computed: {
+        ...mapGetters({
+            projects: 'projects/all',
+        }),
+        ...mapState({
+            user: state => state.Auth.user,
+        }),
+    },
+};
+</script>

--- a/resources/js/pages/Auth/AccountEditor.vue
+++ b/resources/js/pages/Auth/AccountEditor.vue
@@ -90,6 +90,8 @@ export default {
         async saveChanges() {
             const { name, email } = this.data;
 
+            this.errors = {};
+
             try {
                 await this.$store.dispatch('updateAccount', { name, email });
             } catch (error) {
@@ -97,11 +99,16 @@ export default {
             }
         },
         async changePassword() {
+            this.errors = {};
+
             try {
                 await this.$store.dispatch('updateAccount', {
                     password: this.data.currentPassword,
                     newPassword: this.data.newPassword,
                     newPassword_confirmation: this.data.confirmPassword,
+                });
+                this.$store.dispatch('logout').then(() => {
+                    this.$router.push({ name: 'login' });
                 });
             } catch (error) {
                 this.errors = error.response.data.errors;

--- a/resources/js/pages/Auth/AccountEditor.vue
+++ b/resources/js/pages/Auth/AccountEditor.vue
@@ -93,7 +93,9 @@ export default {
             try {
                 await this.$store.dispatch('updateAccount', { name, email });
             } catch (error) {
-                this.errors.push(error);
+                const { response: res } = error;
+
+                this.errors = res.data.errors;
             }
         },
     },

--- a/resources/js/pages/Auth/AccountEditor.vue
+++ b/resources/js/pages/Auth/AccountEditor.vue
@@ -1,13 +1,13 @@
 <template>
     <sui-grid container>
         <sui-grid-column>
-            <sui-form @submit.prevent="save()">
-                <h2>Account Settings</h2>
+            <h2>Account Settings</h2>
 
-                <sui-segment>
+            <sui-segment>
+                <sui-form @submit.prevent="saveChanges()">
                     <sui-form-field :error="'name' in errors">
                         <label>Account Name</label>
-                        <sui-input required v-model="data.name"
+                        <sui-input v-model="data.name"
                             :placeholder="user.name" />
                         <sui-label basic color="red" pointing
                             v-if="'name' in errors">
@@ -17,16 +17,21 @@
 
                     <sui-form-field :error="'email' in errors">
                         <label>Email Address</label>
-                        <sui-input required type="email" v-model="data.email"
+                        <sui-input type="email" v-model="data.email"
                             :placeholder="user.email" />
                         <sui-label basic color="red" pointing
                             v-if="'email' in errors">
                             {{ errors['email'][0] }}
                         </sui-label>
                     </sui-form-field>
-                </sui-segment>
 
-                <sui-segment>
+                    <sui-button primary type="submit"
+                                content="Save changes" />
+                </sui-form>
+            </sui-segment>
+
+            <sui-segment>
+                <sui-form>
                     <sui-form-field>
                         <label>Current Password</label>
                         <sui-input required type="password" v-model="data.currentPassword" />
@@ -53,12 +58,12 @@
                             {{ errors['confirmPassword'][0] }}
                         </sui-label>
                     </sui-form-field>
-                </sui-segment>
 
-                <sui-button primary floated="right"
-                            content="Save changes" />
+                    <sui-button primary type="submit"
+                                content="Change password" />
+                </sui-form>
+            </sui-segment>
 
-            </sui-form>
         </sui-grid-column>
     </sui-grid>
 </template>
@@ -70,7 +75,7 @@ export default {
     data() {
         return {
             data: {},
-            errors: {},
+            errors: [],
         };
     },
     computed: {
@@ -80,6 +85,17 @@ export default {
         ...mapState({
             user: state => state.Auth.user,
         }),
+    },
+    methods: {
+        async saveChanges() {
+            const { name, email } = this.data;
+
+            try {
+                await this.$store.dispatch('updateAccount', { name, email });
+            } catch (error) {
+                this.errors.push(error);
+            }
+        },
     },
 };
 </script>

--- a/resources/js/routes.js
+++ b/resources/js/routes.js
@@ -1,3 +1,4 @@
+import AccountEditor from './pages/Auth/AccountEditor';
 import DatabaseList from './pages/Databases/DatabaseList';
 import DatabaseViewer from './pages/Databases/DatabaseViewer';
 import Databases from './pages/Databases';
@@ -21,6 +22,11 @@ const routes = [{
         name: 'dashboard',
         path: '/',
         redirect: 'projects',
+        meta: { auth: true },
+    }, {
+        name: 'account',
+        path: '/account',
+        component: AccountEditor,
         meta: { auth: true },
     }, {
         path: '/projects',

--- a/resources/js/store/modules/Auth.js
+++ b/resources/js/store/modules/Auth.js
@@ -74,6 +74,14 @@ export default {
 
             commit('setUser', response.data);
         },
+        updateAccount: ({ commit }, data) => new Promise((resolve, reject) => {
+            axios.put('/api/user', data).then(response => {
+                commit('setUser', response.data);
+                resolve(response);
+            }).catch(error => {
+                reject(error);
+            });
+        }),
         forceLogin: ({ commit }, reason) => {
             commit('setAlert', { title: reason, msg: 'Please login again.' });
             commit('clearUser');

--- a/resources/sass/layout/_sidebar.scss
+++ b/resources/sass/layout/_sidebar.scss
@@ -19,16 +19,16 @@
         }
 
         .item i.chevron.up {
-            transition: 0.3s;
+            transition: 0.6s;
         }
 
         &:hover {
-            max-height: 80px;
+            max-height: 110px;
             transition: max-height .2s ease-in;
 
             .item i.chevron.up {
                 transform: rotate(-180deg);
-                transition: 0.3s;
+                transition: 0.5s;
             }
         }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ use Servidor\Http\Controllers\System\GroupsController;
 use Servidor\Http\Controllers\System\UsersController;
 use Servidor\Http\Controllers\SystemInformationController;
 use Servidor\Http\Controllers\User\ShowProfile;
+use Servidor\Http\Controllers\User\UpdateAccount;
 
 Route::post('register', Register::class);
 Route::middleware('web')->name('login')->post('session', Login::class);
@@ -73,6 +74,7 @@ Route::middleware('auth:api')->group(static function (): void {
 
     Route::get('system-info', SystemInformationController::class);
     Route::get('user', ShowProfile::class);
+    Route::put('user', UpdateAccount::class);
 });
 
 Route::any('/{all?}', [FallbackController::class, 'api'])->where('all', '.*');

--- a/tests/Feature/Api/User/UpdateAccountTest.php
+++ b/tests/Feature/Api/User/UpdateAccountTest.php
@@ -23,7 +23,7 @@ class UpdateAccountTest extends TestCase
         $request = $this->authed();
         $data = [
             'name' => $this->user->name . ' (changed)',
-            'email' => $this->user->email . ' (changed)',
+            'email' => 'changed-' . $this->user->email,
         ];
         $response = $request->putJson('/api/user', $data);
 
@@ -33,5 +33,19 @@ class UpdateAccountTest extends TestCase
             'created_at', 'updated_at',
         ]);
         $response->assertJsonFragment($data);
+    }
+
+    /** @test */
+    public function email_must_be_valid(): void
+    {
+        $request = $this->authed();
+        $data = [
+            'email' => 'notanemail',
+        ];
+        $response = $request->putJson('/api/user', $data);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrorFor('email');
+        $response->assertJsonFragment(['email' => [__('validation.email', ['attribute' => 'email'])]]);
     }
 }

--- a/tests/Feature/Api/User/UpdateAccountTest.php
+++ b/tests/Feature/Api/User/UpdateAccountTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Api\User;
+
+use Tests\RequiresAuth;
+use Tests\TestCase;
+
+class UpdateAccountTest extends TestCase
+{
+    use RequiresAuth;
+
+    /** @test */
+    public function guest_attempts_respond_with_401(): void
+    {
+        $response = $this->getJson('/api/user');
+
+        $response->assertUnauthorized();
+    }
+
+    /** @test */
+    public function can_update_name_and_email_without_current_password(): void
+    {
+        $request = $this->authed();
+        $data = [
+            'name' => $this->user->name . ' (changed)',
+            'email' => $this->user->email . ' (changed)',
+        ];
+        $response = $request->putJson('/api/user', $data);
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'id', 'name', 'email',
+            'created_at', 'updated_at',
+        ]);
+        $response->assertJsonFragment($data);
+    }
+}

--- a/tests/Feature/Api/User/UpdateAccountTest.php
+++ b/tests/Feature/Api/User/UpdateAccountTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Feature\Api\User;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
 use Tests\RequiresAuth;
 use Tests\TestCase;
 
 class UpdateAccountTest extends TestCase
 {
+    use RefreshDatabase;
     use RequiresAuth;
 
     /** @test */
@@ -47,5 +50,74 @@ class UpdateAccountTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonValidationErrorFor('email');
         $response->assertJsonFragment(['email' => [__('validation.email', ['attribute' => 'email'])]]);
+    }
+
+    /** @test */
+    public function can_update_password_without_name_or_email(): void
+    {
+        $request = $this->authed();
+        $oldPassword = Hash::make('dogs');
+        $this->user->update(['password' => $oldPassword]);
+
+        $response = $request->putJson('/api/user', [
+            'password' => 'dogs',
+            'newPassword' => 'kittens!',
+            'newPassword_confirmation' => 'kittens!',
+        ]);
+
+        $response->assertOk();
+        $this->assertNotSame($oldPassword, $this->user->password, 'The password did not change.');
+        $this->assertTrue(Hash::check('kittens!', $this->user->password), 'The password hash does not match.');
+        $response->assertJsonStructure([
+            'id', 'name', 'email',
+            'created_at', 'updated_at',
+        ]);
+    }
+
+    /** @test
+     * @dataProvider passwordData
+     */
+    public function updating_password_requires_valid_data(array $data, array $expectedErrors): void
+    {
+        $request = $this->authed();
+        $this->user->update(['password' => Hash::make('oldpass')]);
+
+        $response = $request->putJson('/api/user', $data);
+
+        $response->assertStatus(422);
+
+        foreach ($expectedErrors as $field => $errors) {
+            $response->assertJsonValidationErrorFor($field);
+            $response->assertJsonFragment([
+                $field => array_map(static fn ($e): string => __(...$e), $errors),
+            ]);
+        }
+    }
+
+    public function passwordData(): array
+    {
+        return [[
+            ['password' => 'wrong'],
+            ['password' => [
+                ['validation.current_password'],
+            ]],
+        ], [
+            ['password' => 'oldpass', 'newPassword' => 'a', 'newPassword_confirmation' => 'a'],
+            ['newPassword' => [
+                ['validation.min.string', ['attribute' => 'new password', 'min' => 8]]],
+            ],
+        ], [
+            ['password' => 'oldpass', 'newPassword' => '12345678', 'newPassword_confirmation' => '01234567'],
+            ['newPassword' => [
+                ['validation.confirmed', ['attribute' => 'new password']],
+            ]],
+        ], [
+            ['password' => 'oldpass', 'newPassword' => '12345678'],
+            ['newPassword_confirmation' => [
+                ['validation.required_with', ['attribute' => 'new password confirmation', 'values' => 'new password']],
+            ], 'newPassword' => [
+                ['validation.confirmed', ['attribute' => 'new password']],
+            ]],
+        ]];
     }
 }

--- a/tests/RequiresAuth.php
+++ b/tests/RequiresAuth.php
@@ -8,7 +8,7 @@ trait RequiresAuth
 {
     private ?User $user;
 
-    protected function authed()
+    protected function authed(): TestCase
     {
         if (!isset($this->user)) {
             $user = User::factory()->create();


### PR DESCRIPTION
Adds a new page, accessible via 'Account Settings' in the bottom-left menu, with two forms for changing the account password or name and email.

A much needed addition, and saves me having to worry about replacing the default user seeder with something more practical in the installer.