### PR TITLE
Bump phpstan up to using level 6 rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [projects] The presence or absence of the 'www.' can now optionally be forced
 
 ### Changed
+* [chore] PHPStan reporting increased from level 5 to 6
 * [projects] App/redirect creation steps are now added to progress modal together
 * [projects] Project Apps and Project Redirects are now simply Project Services
 

--- a/app/Databases/DatabaseData.php
+++ b/app/Databases/DatabaseData.php
@@ -3,7 +3,6 @@
 namespace Servidor\Databases;
 
 use Servidor\Http\Requests\Databases\NewDatabase;
-use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelData\Optional;
@@ -12,8 +11,7 @@ class DatabaseData extends Data
 {
     public function __construct(
         public string $name,
-        /** @phan-suppress-next-line PhanAttributeWrongTarget */
-        #[DataCollectionOf(TableData::class)]
+        /** @var DataCollection<int, TableData>|Optional */
         public DataCollection|Optional $tables,
         public string $charset = '',
         public string $collation = '',
@@ -31,6 +29,7 @@ class DatabaseData extends Data
         return new self($name, new Optional());
     }
 
+    /** @param array<mixed> $tables */
     public function withTables(array $tables): self
     {
         return self::from([

--- a/app/Databases/DatabaseManager.php
+++ b/app/Databases/DatabaseManager.php
@@ -5,6 +5,7 @@ namespace Servidor\Databases;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Illuminate\Contracts\Config\Repository;
 use Spatie\LaravelData\DataCollection;
@@ -15,8 +16,10 @@ class DatabaseManager
 
     private Connection $connection;
 
+    /** @var AbstractSchemaManager<AbstractPlatform> */
     private AbstractSchemaManager $manager;
 
+    /** @param AbstractSchemaManager<AbstractPlatform>|null $manager */
     public function __construct(
         Repository $config,
         ?Connection $connection = null,
@@ -52,6 +55,11 @@ class DatabaseManager
         return $data;
     }
 
+    /**
+     * @phpstan-return DataCollection<int, DatabaseData>
+     *
+     * @psalm-return DataCollection<array-key, mixed>
+     */
     public function databases(): DataCollection
     {
         $databases = DatabaseData::collection($this->manager->listDatabases());
@@ -61,6 +69,11 @@ class DatabaseManager
         return $databases;
     }
 
+    /**
+     * @phpstan-return DataCollection<int, DatabaseData>
+     *
+     * @psalm-return DataCollection<array-key, mixed>
+     */
     public function detailedDatabases(): DataCollection
     {
         $databases = [];

--- a/app/Databases/TableData.php
+++ b/app/Databases/TableData.php
@@ -16,7 +16,16 @@ class TableData extends Data
     }
 
     /**
-     * @param array{TABLE_NAME:string,TABLE_COLLATION:string,ENGINE:string,TABLE_ROWS:int,DATA_LENGTH:int} $result
+     * @suppress PhanUnextractableAnnotationElementName
+     * @suppress PhanUnextractableAnnotationSuffix
+     *
+     * @param array{
+     *   TABLE_NAME: string,
+     *   TABLE_COLLATION: string,
+     *   ENGINE: string,
+     *   TABLE_ROWS: int,
+     *   DATA_LENGTH: int
+     * } $result
      */
     public static function fromInfoSchema(array $result): self
     {

--- a/app/FileManager/FileManager.php
+++ b/app/FileManager/FileManager.php
@@ -25,6 +25,9 @@ class FileManager
         $this->finder = new Finder();
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
     public function list(string $path): array
     {
         // Symfony's Finder trims all slashes from the end,
@@ -42,6 +45,9 @@ class FileManager
         }
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
     private function getFiles(string $path): array
     {
         /** @psalm-suppress TooManyArguments - sortByName */
@@ -56,6 +62,9 @@ class FileManager
         return array_map([$this, 'fileToArray'], $files);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function createDir(string $path): array
     {
         if (file_exists($path)) {
@@ -68,6 +77,9 @@ class FileManager
         return $this->open($path, false);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function createFile(string $file, string $contents): array
     {
         if (file_exists($file)) {
@@ -80,6 +92,9 @@ class FileManager
         return $this->open($file);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function open(string $file, bool $includeContent = true): array
     {
         if (!file_exists($file)) {
@@ -100,6 +115,9 @@ class FileManager
         return false !== file_put_contents($file, $contents);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function move(string $path, string $target): array
     {
         if (!file_exists($path)) {
@@ -133,6 +151,7 @@ class FileManager
         return unlink($path);
     }
 
+    /** @return array<string,array{text:string,octal:string}> */
     private function loadFilePermissions(string $path): array
     {
         $pathParts = explode('/', $path);
@@ -147,6 +166,7 @@ class FileManager
         return $this->loadPermissions($path, $name);
     }
 
+    /** @return array<string, array{text: string, octal: string}> */
     private function loadPermissions(string $path, string $name = '.* *'): array
     {
         $perms = [];
@@ -169,7 +189,7 @@ class FileManager
     }
 
     /**
-     * @return array{0: SplFileInfo, 1: array}
+     * @return array{0: SplFileInfo, 1: array<string, mixed>}
      */
     private function loadFile(SplFileInfo|string $file): array
     {
@@ -185,6 +205,8 @@ class FileManager
 
     /**
      * @SuppressWarnings(PHPMD.ErrorControlOperator)
+     *
+     * @return array<string,mixed>
      */
     private function makeFileData(SplFileInfo $file): array
     {
@@ -204,7 +226,11 @@ class FileManager
         ];
     }
 
-    /** @param SplFileInfo|string $file */
+    /**
+     * @param SplFileInfo|string $file
+     *
+     * @return array<string, mixed>
+     */
     private function fileToArray($file): array
     {
         [$_, $data] = $this->loadFile($file);
@@ -212,6 +238,9 @@ class FileManager
         return $data;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function fileWithContents(string $file): array
     {
         [$file, $data] = $this->loadFile($file);
@@ -233,6 +262,11 @@ class FileManager
         return $data;
     }
 
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
     private function addErrorFromException(RuntimeException $e, array $data): array
     {
         $msg = $e->getMessage();

--- a/app/Http/Controllers/Auth/Register.php
+++ b/app/Http/Controllers/Auth/Register.php
@@ -10,6 +10,7 @@ use Servidor\User;
 
 class Register extends Controller
 {
+    /** @var array<string, mixed> */
     private array $validationRules = [
         'name' => ['required', 'string', 'max:255'],
         'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],

--- a/app/Http/Controllers/System/Git/ListBranches.php
+++ b/app/Http/Controllers/System/Git/ListBranches.php
@@ -11,19 +11,25 @@ class ListBranches extends Controller
 {
     private const GIT_COMMAND = "git ls-remote --heads '%s' | sed 's^.*refs/heads/^^'";
 
+    /** @var array<string, string> */
     private array $patterns = ProjectService::SOURCE_PROVIDERS;
 
     public function __invoke(Request $request): JsonResponse
     {
         [$repo, $provider] = $this->validateParams((array) $request->query());
 
-        $repo = str_replace('{repo}', (string) $repo, (string) $this->patterns[(string) $provider]);
+        $repo = str_replace('{repo}', $repo, $this->patterns[$provider]);
 
         exec(sprintf(self::GIT_COMMAND, $repo), $branches);
 
         return response()->json($branches);
     }
 
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array{0: string, 1: string}
+     */
     private function validateParams(array $data): array
     {
         $repo = $data['repository'] ?? '';

--- a/app/Http/Controllers/System/UsersController.php
+++ b/app/Http/Controllers/System/UsersController.php
@@ -35,6 +35,11 @@ class UsersController extends Controller
         return response()->json($user, Response::HTTP_CREATED);
     }
 
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array<string, mixed>
+     */
     private function createUser(CreateUser $request, array $data): array
     {
         $user = new LinuxUser(['name' => $data['name']]);
@@ -60,10 +65,12 @@ class UsersController extends Controller
     public function update(UpdateUser $request, int $uid): JsonResponse
     {
         try {
+            /** @var array<string, mixed> $data */
+            $data = (array) $request->validated();
             $user = SystemUser::find($uid);
 
             return response()->json(
-                $user->update((array) $request->validated()),
+                $user->update($data),
                 Response::HTTP_OK,
             );
         } catch (UserNotFound $_) {

--- a/app/Http/Requests/CreateProjectRequest.php
+++ b/app/Http/Requests/CreateProjectRequest.php
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class CreateProjectRequest extends FormRequest
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/Databases/NewDatabase.php
+++ b/app/Http/Requests/Databases/NewDatabase.php
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class NewDatabase extends FormRequest
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [
@@ -16,12 +19,14 @@ class NewDatabase extends FormRequest
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
+     * @suppress PhanUnextractableAnnotationElementName
+     * @suppress PhanUnextractableAnnotationSuffix
      * @suppress PhanUnusedPublicMethodParameter
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      *
-     * @param array|int|string|null $key
-     * @param mixed                 $default
+     * @param array<array-key, mixed>|int|string|null $key
+     * @param mixed                                   $default
      *
      * @return array{database: string}
      */

--- a/app/Http/Requests/FileManager/EditFile.php
+++ b/app/Http/Requests/FileManager/EditFile.php
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class EditFile extends FormRequest
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [
@@ -14,6 +17,9 @@ class EditFile extends FormRequest
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function messages(): array
     {
         return [
@@ -26,10 +32,12 @@ class EditFile extends FormRequest
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      *
+     * @suppress PhanUnextractableAnnotationSuffix
+     * @suppress PhanUnextractableAnnotationElementName
      * @suppress PhanUnusedPublicMethodParameter
      *
-     * @param array|int|string|null $key
-     * @param mixed                 $default
+     * @param array<array-key, mixed>|int|string|null $key
+     * @param mixed                                   $default
      *
      * @return array{file: string, contents: string}
      */

--- a/app/Http/Requests/Projects/NewProjectService.php
+++ b/app/Http/Requests/Projects/NewProjectService.php
@@ -18,6 +18,7 @@ class NewProjectService extends FormRequest
     private const GIT_NO_REFS = 2;
     private const GIT_NOT_FOUND = 128;
 
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         $rules = [
@@ -36,7 +37,7 @@ class NewProjectService extends FormRequest
     }
 
     /**
-     * @return array<string,array|string>
+     * @return array<string,array<string>|string>
      */
     private function configRules(): array
     {
@@ -63,7 +64,7 @@ class NewProjectService extends FormRequest
     }
 
     /**
-     * @return array<string,array|string>
+     * @return array<string,array<string>|string>
      */
     private function sourceRules(): array
     {
@@ -87,18 +88,29 @@ class NewProjectService extends FormRequest
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @suppress PhanUnusedPublicMethodParameter
+     * @suppress PhanUnextractableAnnotationSuffix
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     *
+     * @param mixed $key
+     * @param mixed $default
+     *
+     * @return array{
+     *  template: string,
+     *  domain_name: string,
+     *  include_www: bool,
+     *  config: array<array-key, mixed>
+     * }
      */
     public function validated($key = null, $default = null): array
     {
         $data = (array) parent::validated();
 
         return [
-            'template' => $data['template'],
-            'domain_name' => $data['domain'],
-            'include_www' => $data['includeWww'] ?? false,
-            'config' => $data['config'] ?? [],
+            'template' => (string) $data['template'],
+            'domain_name' => (string) $data['domain'],
+            'include_www' => (bool) ($data['includeWww'] ?? null),
+            'config' => (array) ($data['config'] ?? null),
         ];
     }
 

--- a/app/Http/Requests/System/SaveGroup.php
+++ b/app/Http/Requests/System/SaveGroup.php
@@ -14,6 +14,9 @@ class SaveGroup extends FormRequest
         return (bool) $this->user();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/System/SaveUser.php
+++ b/app/Http/Requests/System/SaveUser.php
@@ -14,6 +14,9 @@ class SaveUser extends FormRequest
         return (bool) $this->user();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/System/UpdateGroup.php
+++ b/app/Http/Requests/System/UpdateGroup.php
@@ -4,6 +4,9 @@ namespace Servidor\Http\Requests\System;
 
 class UpdateGroup extends SaveGroup
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return array_merge(parent::rules(), [

--- a/app/Http/Requests/System/UpdateUser.php
+++ b/app/Http/Requests/System/UpdateUser.php
@@ -4,6 +4,9 @@ namespace Servidor\Http\Requests\System;
 
 class UpdateUser extends SaveUser
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return array_merge(parent::rules(), [

--- a/app/Http/Requests/UpdateProjectRequest.php
+++ b/app/Http/Requests/UpdateProjectRequest.php
@@ -12,6 +12,9 @@ class UpdateProjectRequest extends FormRequest
         return (bool) $this->user();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [

--- a/app/Projects/Actions/EnableOrDisableProject.php
+++ b/app/Projects/Actions/EnableOrDisableProject.php
@@ -2,7 +2,6 @@
 
 namespace Servidor\Projects\Actions;
 
-use Servidor\Projects\Project;
 use Servidor\Projects\ProjectService;
 
 class EnableOrDisableProject
@@ -22,7 +21,6 @@ class EnableOrDisableProject
 
     public function execute(): void
     {
-        \assert($this->service->project instanceof Project);
         $target = self::PATH_AVAILABLE . $this->configFile;
         $symlink = self::PATH_ENABLED . $this->configFile;
 

--- a/app/Projects/Actions/SaveSslCertificate.php
+++ b/app/Projects/Actions/SaveSslCertificate.php
@@ -11,6 +11,11 @@ use Servidor\Projects\ProjectService;
 
 class SaveSslCertificate
 {
+    /**
+     * @phan-var Collection<mixed>
+     *
+     * @psalm-var Collection<array-key, mixed>
+     */
     private Collection $config;
 
     public function __construct(private ProjectService $service)
@@ -34,7 +39,6 @@ class SaveSslCertificate
 
     public function execute(): void
     {
-        \assert($this->service->project instanceof Project);
         $this->createCertsDir($this->service->project);
 
         \assert($this->service->config instanceof Collection);
@@ -49,6 +53,11 @@ class SaveSslCertificate
         return mkdir($path, 02750, true);
     }
 
+    /**
+     * @phan-param Collection<mixed> $config
+     *
+     * @psalm-param Collection<array-key, mixed> $config
+     */
     private function saveCert(Collection $config): string
     {
         $cert = (string) $config->get('sslCertificate');
@@ -56,6 +65,11 @@ class SaveSslCertificate
         return $this->saveFile($cert, 'crt');
     }
 
+    /**
+     * @phan-param Collection<mixed> $config
+     *
+     * @psalm-param Collection<array-key, mixed> $config
+     */
     private function saveKey(Collection $config): string
     {
         $key = (string) $config->get('sslPrivateKey');
@@ -65,7 +79,6 @@ class SaveSslCertificate
 
     private function saveFile(string $contents, string $extension): string
     {
-        \assert($this->service->project instanceof Project);
         $projectName = $this->service->project->name;
         $file = $this->service->domain_name . '.' . $extension;
         $path = storage_path('certs/' . Str::slug($projectName) . '/' . $file);

--- a/app/Projects/Actions/SyncAppFiles.php
+++ b/app/Projects/Actions/SyncAppFiles.php
@@ -8,6 +8,11 @@ class SyncAppFiles
 {
     private string $sourcePath = '';
 
+    /**
+     * @var array<array-key, mixed>
+     *
+     * @suppress PhanUnextractableAnnotationSuffix
+     */
     private array $output = [];
 
     private int $status = 0;
@@ -23,7 +28,7 @@ class SyncAppFiles
     public function execute(): void
     {
         $user = $this->service->template()->requiresUser()
-              ? (string) ($this->service->system_user['name'] ?? '')
+              ? $this->service->system_user['name'] ?? ''
               : 'www-data';
 
         if (!is_dir($this->sourcePath)) {

--- a/app/Projects/ProgressStep.php
+++ b/app/Projects/ProgressStep.php
@@ -55,6 +55,7 @@ class ProgressStep
         return $this;
     }
 
+    /** @return array{name: string, progress: int, reason: string, status: string, text: string} */
     public function toArray(): array
     {
         return [

--- a/app/Projects/Project.php
+++ b/app/Projects/Project.php
@@ -11,13 +11,13 @@ use Illuminate\Support\Carbon;
 /**
  * A Project is a container for one or more ProjectServices.
  *
- * @property int                              $id
- * @property string                           $name
- * @property bool                             $is_enabled
- * @property ?Carbon                          $created_at
- * @property ?Carbon                          $updated_at
- * @property array<ProjectService>|Collection $services
- * @property ?int                             $services_count
+ * @property int                        $id
+ * @property string                     $name
+ * @property bool                       $is_enabled
+ * @property ?Carbon                    $created_at
+ * @property ?Carbon                    $updated_at
+ * @property Collection<ProjectService> $services
+ * @property ?int                       $services_count
  *
  * @method static Project         create()
  * @method static ?Project        find()
@@ -40,12 +40,14 @@ class Project extends Model
         'is_enabled' => 'boolean',
     ];
 
+    /** @var array<mixed> */
     protected $dispatchesEvents = [
         'saved' => ProjectSaved::class,
     ];
 
     protected $table = 'projects';
 
+    /** @return HasMany<ProjectService> */
     public function services(): HasMany
     {
         return $this->hasMany(ProjectService::class);

--- a/app/Projects/ProjectProgress.php
+++ b/app/Projects/ProjectProgress.php
@@ -37,6 +37,7 @@ class ProjectProgress implements ShouldBroadcast
         return new PrivateChannel('projects.' . $this->project->id);
     }
 
+    /** @return array{project: Project, step: array<string, int|string>} */
     public function broadcastWith(): array
     {
         return [

--- a/app/Projects/ProjectSaved.php
+++ b/app/Projects/ProjectSaved.php
@@ -2,7 +2,6 @@
 
 namespace Servidor\Projects;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Queue\SerializesModels;
 
 class ProjectSaved
@@ -19,7 +18,6 @@ class ProjectSaved
     public function getService(): ?ProjectService
     {
         $services = $this->project->services;
-        \assert($services instanceof Collection);
 
         if (0 === $services->count()) {
             return null;

--- a/app/Projects/ProjectService.php
+++ b/app/Projects/ProjectService.php
@@ -54,6 +54,7 @@ class ProjectService extends Model
         'custom' => '{repo}',
     ];
 
+    /** @var array<mixed> */
     protected $appends = [
         'document_root',
         'logs',
@@ -66,6 +67,7 @@ class ProjectService extends Model
         'config' => 'collection',
     ];
 
+    /** @var array<mixed> */
     protected $dispatchesEvents = [
         'saving' => ProjectServiceSaving::class,
         'saved' => ProjectServiceSaved::class,
@@ -93,16 +95,23 @@ class ProjectService extends Model
         $this->template()->checkNginxData();
     }
 
+    /** @return array<string, string> */
     public function getLogsAttribute(): array
     {
         return array_map(static fn (LogFile $log): string => $log->getTitle(), $this->logs());
     }
 
+    /** @return array<string, LogFile> */
     public function logs(): array
     {
         return $this->template()->getLogs();
     }
 
+    /**
+     * @phpstan-return BelongsTo<Project, self>
+     *
+     * @psalm-return BelongsTo<Project>
+     * */
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
@@ -127,11 +136,10 @@ class ProjectService extends Model
         if ($this->template()->requiresUser() && $this->systemUser) {
             // TODO: If user doesn't exist, this should throw UserNotFoundException
             //  (or some similar error) and NOT just default to a root-based path!
-            return ((string) $this->systemUser['dir']) . '/' . $this->sourceRepoName;
+            return $this->systemUser['dir'] . '/' . $this->sourceRepoName;
         }
 
         $project = $this->project;
-        \assert($project instanceof Project);
 
         return '/var/www/' . Str::slug($project->name) . '/' . $this->sourceRepoName;
     }
@@ -149,6 +157,7 @@ class ProjectService extends Model
         return str_replace('{repo}', $repo, self::SOURCE_PROVIDERS[$provider ?: 'custom']);
     }
 
+    /** @return array{name: string, dir: string, groups: array<string>, shell: string, gid: ?int, uid: ?int}|null */
     public function getSystemUserAttribute(): ?array
     {
         if (!$this->template()->requiresUser()) {

--- a/app/Projects/RequiresNginxData.php
+++ b/app/Projects/RequiresNginxData.php
@@ -39,7 +39,7 @@ trait RequiresNginxData
             [$key, $property] = explode('.', $property);
 
             /**
-             * @var array $key
+             * @var array<string, mixed> $key
              *
              * @psalm-suppress InvalidArgument
              * */

--- a/app/Projects/Services/ProjectServiceSaved.php
+++ b/app/Projects/Services/ProjectServiceSaved.php
@@ -16,8 +16,6 @@ class ProjectServiceSaved
 
     public function __construct(ProjectService $service)
     {
-        \assert($service->project instanceof Project);
-
         $this->service = $service;
         $this->project = $service->project;
     }

--- a/app/Projects/Services/ProjectServiceSaving.php
+++ b/app/Projects/Services/ProjectServiceSaving.php
@@ -15,8 +15,6 @@ class ProjectServiceSaving
     public function __construct(
         private ProjectService $service,
     ) {
-        \assert($service->project instanceof Project);
-
         $this->project = $service->project;
     }
 

--- a/app/Projects/Services/Templates/Html.php
+++ b/app/Projects/Services/Templates/Html.php
@@ -15,6 +15,9 @@ class Html implements Template
 
     protected string $publicDir = '';
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $requiredNginxData = [
         'domain_name' => 'domain name',
         'config.source.repository' => 'source repo',

--- a/app/Projects/Services/Templates/Redirect.php
+++ b/app/Projects/Services/Templates/Redirect.php
@@ -9,6 +9,9 @@ class Redirect implements Template
 {
     use RequiresNginxData;
 
+    /**
+     * @var array<string, string>
+     */
     protected array $requiredNginxData = [
         'config.redirect.target' => 'target',
         'domain_name' => 'domain name',

--- a/app/Projects/Services/Templates/Template.php
+++ b/app/Projects/Services/Templates/Template.php
@@ -3,11 +3,15 @@
 namespace Servidor\Projects\Services\Templates;
 
 use Servidor\Projects\ProjectService;
+use Servidor\Projects\Services\LogFile;
 
 interface Template
 {
     public function getService(): ProjectService;
 
+    /**
+     * @return array<string, LogFile>
+     */
     public function getLogs(): array;
 
     public function nginxTemplate(): string;

--- a/app/StatsBar.php
+++ b/app/StatsBar.php
@@ -4,10 +4,23 @@ namespace Servidor;
 
 class StatsBar
 {
+    /**
+     * @suppress PhanUnextractableAnnotationSuffix
+     *
+     * @return array{
+     *   cpu: float,
+     *   load_average: array{'1m': string, '5m': string, '15m': string},
+     *   ram: array{total: float, used: float, free: float},
+     *   disk: array<string, string>,
+     *   hostname: string,
+     *   os: array{name: string, distro: string, version: string}
+     * }
+     */
     public static function stats(): array
     {
         $os = self::parseReleaseFile('os');
         $lsb = self::parseReleaseFile('lsb');
+        \assert(isset($os['NAME'], $lsb['DISTRIB_RELEASE']));
 
         return [
             'cpu' => self::getCpuUsage(),
@@ -23,6 +36,7 @@ class StatsBar
         ];
     }
 
+    /** @return array<string, string> */
     private static function parseReleaseFile(string $file): array
     {
         $flags = FILE_IGNORE_NEW_LINES;
@@ -50,6 +64,10 @@ class StatsBar
 
     /**
      * Get the CPU load average over 1, 5 and 15 minute intervals.
+     *
+     * @suppress PhanUnextractableAnnotationSuffix
+     *
+     * @return array{'1m': string, '5m': string, '15m': string}
      */
     private static function getLoadAverage(): array
     {
@@ -64,6 +82,8 @@ class StatsBar
 
     /**
      * Get details about the RAM currently used/free.
+     *
+     * @return array{total: float, used: float, free: float}
      */
     private static function getRamUsage(): array
     {
@@ -81,6 +101,8 @@ class StatsBar
 
     /**
      * Get the disk usage details for the root mountpoint.
+     *
+     * @return array<string, string>
      */
     private static function getDiskUsage(): array
     {

--- a/app/System/Group.php
+++ b/app/System/Group.php
@@ -26,9 +26,9 @@ class Group
     private array $errors;
 
     /**
-     * @param array|LinuxGroup $group
+     * @param array<string, mixed>|LinuxGroup $group
      */
-    public function __construct($group)
+    public function __construct(array|LinuxGroup $group)
     {
         $this->group = $group instanceof LinuxGroup
                      ? $group : new LinuxGroup($group);
@@ -102,6 +102,7 @@ class Group
         }
     }
 
+    /** @return array<string, mixed> */
     public static function create(string $name, bool $system = false, ?int $gid = null): array
     {
         $group = new self(
@@ -131,25 +132,40 @@ class Group
         return new self($group);
     }
 
+    /**
+     * @psalm-return Collection<int<0, max>, array{
+     *   name: string, password: string, gid: string, users: list<string>
+     * }>
+     *
+     * @phpstan-return Collection<int, array{
+     *   name: string, password: string, gid: string, users: list<string>
+     * }>
+     */
     public static function list(): Collection
     {
-        exec('cat /etc/group', $lines);
-
-        $keys = ['name', 'password', 'gid', 'users'];
         $groups = [];
+        exec('cat /etc/group', $lines);
 
         foreach ($lines as $line) {
             \assert(\is_string($line));
+            $line = explode(':', $line);
 
-            $group = array_combine($keys, explode(':', $line));
-            $group['users'] = '' === $group['users'] ? [] : explode(',', $group['users']);
-
-            $groups[] = $group;
+            $groups[] = [
+                'name' => $line[0],
+                'password' => $line[1],
+                'gid' => $line[2],
+                'users' => '' === $line[3] ? [] : explode(',', $line[3]),
+            ];
         }
 
         return collect($groups);
     }
 
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array<string, mixed>
+     */
     public function update(array $data): array
     {
         /** @var array<string>|null $users */
@@ -170,20 +186,21 @@ class Group
         return $this->refresh($this->group->gid ?? $this->group->name)->toArray();
     }
 
-    /**
-     * @param int|string $nameOrGid
-     */
+    /** @param int|string $nameOrGid */
     private function refresh($nameOrGid): self
     {
+        /** @var array<string, mixed>|false $arr */
         $arr = \is_int($nameOrGid)
              ? posix_getgrgid($nameOrGid)
              : posix_getgrnam($nameOrGid);
+        \assert(false !== $arr);
 
-        $this->group = new LinuxGroup((array) $arr);
+        $this->group = new LinuxGroup($arr);
 
         return $this;
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return $this->group->toArray();

--- a/app/System/Groups/LinuxGroup.php
+++ b/app/System/Groups/LinuxGroup.php
@@ -18,6 +18,7 @@ class LinuxGroup extends LinuxCommand
      */
     public array $users;
 
+    /** @param array<string, mixed> $group */
     public function __construct(array $group = [])
     {
         $this->gid = $group['gid'] ?? null ? (int) $group['gid'] : null;
@@ -29,6 +30,7 @@ class LinuxGroup extends LinuxCommand
         $this->setOriginal();
     }
 
+    /** @return static */
     public function setGid(?int $gid = null): self
     {
         if (isset($gid) && $gid > 0) {
@@ -42,6 +44,7 @@ class LinuxGroup extends LinuxCommand
         return $this;
     }
 
+    /** @return static */
     public function setName(string $name): self
     {
         $this->name = $name;
@@ -53,6 +56,7 @@ class LinuxGroup extends LinuxCommand
         return $this;
     }
 
+    /** @return static */
     public function setSystem(bool $enabled): self
     {
         return $this->toggleArg($enabled, '-r');
@@ -60,6 +64,8 @@ class LinuxGroup extends LinuxCommand
 
     /**
      * @param array<string>|null $users
+     *
+     * @return static
      */
     public function setUsers(?array $users): self
     {

--- a/app/System/LinuxCommand.php
+++ b/app/System/LinuxCommand.php
@@ -4,13 +4,13 @@ namespace Servidor\System;
 
 abstract class LinuxCommand
 {
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     protected array $args = [];
 
+    /** @var array<string, mixed> */
     protected array $original = [];
 
+    /** @return array<string> */
     public function getArgs(): array
     {
         return $this->args;
@@ -39,5 +39,6 @@ abstract class LinuxCommand
         $this->original = $this->toArray();
     }
 
+    /** @return array<string, mixed> */
     abstract public function toArray(): array;
 }

--- a/app/System/Users/LinuxUser.php
+++ b/app/System/Users/LinuxUser.php
@@ -24,6 +24,7 @@ class LinuxUser extends LinuxCommand
 
     public string $shell;
 
+    /** @param array<string, mixed> $user */
     public function __construct(array $user = [], bool $loadGroups = false)
     {
         $this->gid = isset($user['gid']) ? (int) $user['gid'] : null;
@@ -158,6 +159,7 @@ class LinuxUser extends LinuxCommand
         return \count($this->args) > 0;
     }
 
+    /** @return array{name: string, dir: string, groups: array<string>, shell: string, gid: ?int, uid: ?int} */
     public function toArray(): array
     {
         return [

--- a/app/Traits/ToggleCommandArgs.php
+++ b/app/Traits/ToggleCommandArgs.php
@@ -9,6 +9,7 @@ trait ToggleCommandArgs
      */
     protected array $args = [];
 
+    /** @return static */
     public function toggleArg(bool $cond, string $on, string $off = ''): self
     {
         $keyOn = array_search($on, $this->args, true);

--- a/build/phpstan/config.neon
+++ b/build/phpstan/config.neon
@@ -2,7 +2,7 @@ includes:
   - ../../vendor/nunomaduro/larastan/extension.neon
   - ../../vendor/phpstan/phpstan-mockery/extension.neon
 parameters:
-  level: 5
+  level: 6
   paths:
     - ../../app
     - ../../tests

--- a/tests/Feature/Api/Databases/ListDatabasesTest.php
+++ b/tests/Feature/Api/Databases/ListDatabasesTest.php
@@ -9,7 +9,7 @@ class ListDatabasesTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/databases';
+    protected string $endpoint = '/api/databases';
 
     /** @test */
     public function can_list_databases(): void

--- a/tests/Feature/Api/Databases/NewDatabaseTest.php
+++ b/tests/Feature/Api/Databases/NewDatabaseTest.php
@@ -12,7 +12,7 @@ class NewDatabaseTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/databases';
+    protected string $endpoint = '/api/databases';
 
     /** @test */
     public function can_create_a_database(): void

--- a/tests/Feature/Api/Databases/ShowDatabaseTest.php
+++ b/tests/Feature/Api/Databases/ShowDatabaseTest.php
@@ -13,7 +13,7 @@ class ShowDatabaseTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/databases/{id}';
+    protected string $endpoint = '/api/databases/{id}';
 
     public function testItCanListTables(): void
     {

--- a/tests/Feature/Api/Files/CreateNodeTest.php
+++ b/tests/Feature/Api/Files/CreateNodeTest.php
@@ -10,7 +10,7 @@ class CreateNodeTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/files';
+    protected string $endpoint = '/api/files';
 
     /** @test */
     public function guest_cannot_create_a_file(): void

--- a/tests/Feature/Api/Files/DeletePathTest.php
+++ b/tests/Feature/Api/Files/DeletePathTest.php
@@ -10,7 +10,7 @@ class DeletePathTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/files';
+    protected string $endpoint = '/api/files';
 
     /** @test */
     public function guest_cannot_delete_a_file(): void

--- a/tests/Feature/Api/Files/EditFileTest.php
+++ b/tests/Feature/Api/Files/EditFileTest.php
@@ -10,7 +10,7 @@ class EditFileTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/files';
+    protected string $endpoint = '/api/files';
 
     /**
      * @test

--- a/tests/Feature/Api/Files/ListFilesTest.php
+++ b/tests/Feature/Api/Files/ListFilesTest.php
@@ -11,7 +11,7 @@ class ListFilesTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/files';
+    protected string $endpoint = '/api/files';
 
     /** @test */
     public function authed_user_can_list_web_root(): void

--- a/tests/Feature/Api/Files/MovePathTest.php
+++ b/tests/Feature/Api/Files/MovePathTest.php
@@ -10,7 +10,7 @@ class MovePathTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/files/rename';
+    protected string $endpoint = '/api/files/rename';
 
     /** @test */
     public function guest_cannot_rename_a_file(): void

--- a/tests/Feature/Api/Files/ShowFileTest.php
+++ b/tests/Feature/Api/Files/ShowFileTest.php
@@ -10,7 +10,7 @@ class ShowFileTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/files';
+    protected string $endpoint = '/api/files';
 
     /** @test */
     public function authed_user_can_view_file_contents(): void

--- a/tests/Feature/Api/Projects/CreateProjectServiceTest.php
+++ b/tests/Feature/Api/Projects/CreateProjectServiceTest.php
@@ -17,7 +17,7 @@ class CreateProjectServiceTest extends TestCase
     use RefreshDatabase;
     use RequiresAuth;
 
-    protected $endpoint = '/api/projects/{id}/services';
+    protected string $endpoint = '/api/projects/{id}/services';
 
     /** @test */
     public function can_create_project_service(): void

--- a/tests/Feature/Api/Projects/CreateProjectTest.php
+++ b/tests/Feature/Api/Projects/CreateProjectTest.php
@@ -15,7 +15,7 @@ class CreateProjectTest extends TestCase
     use RefreshDatabase;
     use RequiresAuth;
 
-    protected $endpoint = '/api/projects';
+    protected string $endpoint = '/api/projects';
 
     /** @test */
     public function guest_cannot_create_project(): void

--- a/tests/Feature/Api/Projects/ListProjectsTest.php
+++ b/tests/Feature/Api/Projects/ListProjectsTest.php
@@ -16,7 +16,7 @@ class ListProjectsTest extends TestCase
     use RefreshDatabase;
     use RequiresAuth;
 
-    protected $endpoint = '/api/projects';
+    protected string $endpoint = '/api/projects';
 
     /** @test */
     public function guest_cannot_list_projects(): void
@@ -41,7 +41,11 @@ class ListProjectsTest extends TestCase
         $response->assertJson(Project::all()->toArray());
     }
 
-    /** @test */
+    /**
+     * @test
+     *
+     * @return array<string, mixed>
+     */
     public function listed_projects_include_services(): array
     {
         $project = Project::create(['name' => 'Laratest']);
@@ -60,8 +64,10 @@ class ListProjectsTest extends TestCase
      * @test
      *
      * @depends listed_projects_include_services
+     *
+     * @param array<string, mixed> $project
      */
-    public function project_services_include_list_of_logs($project): void
+    public function project_services_include_list_of_logs(array $project): void
     {
         $service = $project['services'][0];
 
@@ -70,7 +76,11 @@ class ListProjectsTest extends TestCase
         $this->assertArraySubset(['laravel' => 'Laravel Log'], $service['logs']);
     }
 
-    /** @test */
+    /**
+     * @test
+     *
+     * @return array<string, mixed>
+     */
     public function listed_projects_include_redirects(): array
     {
         $project = Project::create(['name' => 'Redirtest']);

--- a/tests/Feature/Api/Projects/Services/NginxConfigGenerationTest.php
+++ b/tests/Feature/Api/Projects/Services/NginxConfigGenerationTest.php
@@ -41,6 +41,7 @@ class NginxConfigGenerationTest extends TestCase
         $this->assertFileEquals('tests/Feature/Api/Projects/nginx-configs/' . $conf, $path);
     }
 
+    /** @return array<int, array<int, bool|int|string>> */
     public function configs(): array
     {
         return [

--- a/tests/Feature/Api/Projects/UpdateProjectTest.php
+++ b/tests/Feature/Api/Projects/UpdateProjectTest.php
@@ -35,7 +35,11 @@ class UpdateProjectTest extends TestCase
         $response->assertStatus(Response::HTTP_UNAUTHORIZED);
     }
 
-    /** @test */
+    /**
+     * @test
+     *
+     * @return array<string, mixed>
+     */
     public function authed_user_can_rename_project(): array
     {
         $project = Project::create(['name' => 'My Other Blog']);
@@ -54,6 +58,8 @@ class UpdateProjectTest extends TestCase
 
     /**
      * @test
+     *
+     * @param array<string, mixed> $data
      *
      * @depends authed_user_can_rename_project
      */
@@ -85,6 +91,8 @@ class UpdateProjectTest extends TestCase
     /**
      * @test
      *
+     * @param array<string, mixed> $data
+     *
      * @dataProvider symlinkProvider
      */
     public function updating_project_also_toggles_symlink(array $data): void
@@ -114,6 +122,7 @@ class UpdateProjectTest extends TestCase
         $this->assertFileDoesNotExist("/etc/nginx/sites-enabled/{$domain}.conf");
     }
 
+    /** @return array<string, mixed> $data */
     public function symlinkProvider(): array
     {
         return [

--- a/tests/Feature/Api/System/Git/ListBranchesTest.php
+++ b/tests/Feature/Api/System/Git/ListBranchesTest.php
@@ -10,7 +10,7 @@ class ListBranchesTest extends TestCase
 {
     use RequiresAuth;
 
-    protected $endpoint = '/api/system/git/branches';
+    protected string $endpoint = '/api/system/git/branches';
 
     /** @test */
     public function guest_cannot_list_branches(): void
@@ -67,6 +67,9 @@ class ListBranchesTest extends TestCase
         $response->assertJsonValidationErrors(['provider']);
     }
 
+    /**
+     * @return array<string, array<int, string>>
+     */
     public function repositoryProvider(): array
     {
         return [

--- a/tests/Feature/Api/System/Groups/DeleteGroupTest.php
+++ b/tests/Feature/Api/System/Groups/DeleteGroupTest.php
@@ -35,8 +35,12 @@ class DeleteGroupTest extends TestCase
         $search->assertJsonFragment(['name' => 'guestdeletetest']);
     }
 
-    /** @test */
-    public function authed_user_can_delete_group()
+    /**
+     * @test
+     *
+     * @return array<string, mixed>
+     */
+    public function authed_user_can_delete_group(): array
     {
         $group = $this->authed()->postJson($this->endpoint, [
             'name' => 'deletetestgroup',
@@ -52,9 +56,11 @@ class DeleteGroupTest extends TestCase
     /**
      * @test
      *
+     * @param array<string, mixed> $group
+     *
      * @depends authed_user_can_delete_group
      */
-    public function group_does_not_exist_after_deletion($group): void
+    public function group_does_not_exist_after_deletion(array $group): void
     {
         $response = $this->authed()->getJson($this->endpoint($group['gid']));
 

--- a/tests/Feature/Api/System/Groups/ListGroupsTest.php
+++ b/tests/Feature/Api/System/Groups/ListGroupsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api\System\Groups;
 
 use Illuminate\Http\Response;
+use Illuminate\Testing\TestResponse;
 use Tests\RequiresAuth;
 
 class ListGroupsTest extends TestCase
@@ -20,7 +21,7 @@ class ListGroupsTest extends TestCase
     }
 
     /** @test */
-    public function authed_user_can_list_groups()
+    public function authed_user_can_list_groups(): TestResponse
     {
         $response = $this->authed()->getJson($this->endpoint);
 
@@ -34,7 +35,7 @@ class ListGroupsTest extends TestCase
      *
      * @depends authed_user_can_list_groups
      */
-    public function list_response_contains_expected_data($response): void
+    public function list_response_contains_expected_data(TestResponse $response): void
     {
         $responseJson = json_decode($response->getContent());
 
@@ -48,7 +49,7 @@ class ListGroupsTest extends TestCase
      *
      * @depends authed_user_can_list_groups
      */
-    public function list_results_include_default_groups($response): void
+    public function list_results_include_default_groups(TestResponse $response): void
     {
         $response->assertJsonFragment(['name' => 'root']);
         $response->assertJsonFragment(['name' => 'users']);

--- a/tests/Feature/Api/System/Groups/TestCase.php
+++ b/tests/Feature/Api/System/Groups/TestCase.php
@@ -6,9 +6,10 @@ use Tests\TestCase as BaseCase;
 
 abstract class TestCase extends BaseCase
 {
-    protected $endpoint = '/api/system/groups';
+    protected string $endpoint = '/api/system/groups';
 
-    protected $expectedKeys = [
+    /** @var array<int, string> */
+    protected array $expectedKeys = [
         'gid',
         'name',
         'users',

--- a/tests/Feature/Api/System/Users/DeleteUserTest.php
+++ b/tests/Feature/Api/System/Users/DeleteUserTest.php
@@ -38,7 +38,11 @@ class DeleteUserTest extends TestCase
         $search->assertJsonFragment(['name' => 'guestdeleteuser']);
     }
 
-    /** @test */
+    /**
+     * @test
+     *
+     * @return array<array-key, mixed>
+     */
     public function authed_user_can_delete_user(): array
     {
         $user = $this->authed()->postJson($this->endpoint, [
@@ -56,9 +60,11 @@ class DeleteUserTest extends TestCase
     /**
      * @test
      *
+     * @param array<array-key, mixed> $user
+     *
      * @depends authed_user_can_delete_user
      */
-    public function user_does_not_exist_after_deletion($user): void
+    public function user_does_not_exist_after_deletion(array $user): void
     {
         $response = $this->authed()->getJson($this->endpoint($user['uid']));
 

--- a/tests/Feature/Api/System/Users/ListUsersTest.php
+++ b/tests/Feature/Api/System/Users/ListUsersTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api\System\Users;
 
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Illuminate\Http\Response;
+use Illuminate\Testing\TestResponse;
 use Tests\PrunesDeletables;
 use Tests\RequiresAuth;
 
@@ -31,7 +32,7 @@ class ListUsersTest extends TestCase
     }
 
     /** @test */
-    public function authed_user_can_list_users()
+    public function authed_user_can_list_users(): TestResponse
     {
         $response = $this->authed()->getJson($this->endpoint);
 
@@ -45,7 +46,7 @@ class ListUsersTest extends TestCase
      *
      * @depends authed_user_can_list_users
      */
-    public function list_includes_normal_users($response): void
+    public function list_includes_normal_users(TestResponse $response): void
     {
         // Vagrant has a vagrant (and ubuntu) user but PHP could be running as
         // www-data instead, so we use the SUDO_USER value that it also sets.
@@ -59,7 +60,7 @@ class ListUsersTest extends TestCase
      *
      * @depends authed_user_can_list_users
      */
-    public function list_includes_system_users($response): void
+    public function list_includes_system_users(TestResponse $response): void
     {
         $response->assertJsonFragment(['name' => 'root']);
     }
@@ -94,7 +95,7 @@ class ListUsersTest extends TestCase
      *
      * @depends authed_user_can_list_users
      */
-    public function list_response_contains_expected_data($response): void
+    public function list_response_contains_expected_data(TestResponse $response): void
     {
         $responseJson = json_decode($response->getContent());
 

--- a/tests/Feature/Api/System/Users/TestCase.php
+++ b/tests/Feature/Api/System/Users/TestCase.php
@@ -6,9 +6,12 @@ use Tests\TestCase as BaseCase;
 
 abstract class TestCase extends BaseCase
 {
-    protected $endpoint = '/api/system/users';
+    protected string $endpoint = '/api/system/users';
 
-    protected $expectedKeys = [
+    /**
+     * @var array<int, string>
+     */
+    protected array $expectedKeys = [
         'name',
         'dir',
         'groups',

--- a/tests/Feature/Api/User/UpdateAccountTest.php
+++ b/tests/Feature/Api/User/UpdateAccountTest.php
@@ -76,6 +76,9 @@ class UpdateAccountTest extends TestCase
 
     /** @test
      * @dataProvider passwordData
+     *
+     * @param array<string, mixed>                   $data
+     * @param array<string, array<array-key, mixed>> $expectedErrors
      */
     public function updating_password_requires_valid_data(array $data, array $expectedErrors): void
     {
@@ -94,6 +97,7 @@ class UpdateAccountTest extends TestCase
         }
     }
 
+    /** @return array<int, mixed> */
     public function passwordData(): array
     {
         return [[

--- a/tests/Feature/Auth/RegisterTest.php
+++ b/tests/Feature/Auth/RegisterTest.php
@@ -11,14 +11,20 @@ class RegisterTest extends TestCase
     use RefreshDatabase;
     use RequiresAuth;
 
-    private $jill = [
+    /**
+     * @var array<string, string>
+     */
+    private array $jill = [
         'name' => 'Jill',
         'email' => 'jill@example.com',
         'password' => 'hunter42',
         'password_confirmation' => 'hunter42',
     ];
 
-    private $jillClean = [
+    /**
+     * @var array<string, string>
+     */
+    private array $jillClean = [
         'name' => 'Jill',
         'email' => 'jill@example.com',
     ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,15 +8,9 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    protected $endpoint = '/api';
+    protected string $endpoint = '/api';
 
-    protected function assertValidationErrors($response, $keys): void
-    {
-        $response->assertStatus(422);
-        $response->assertJsonValidationErrors($keys);
-    }
-
-    protected function endpoint($id = null): string
+    protected function endpoint(mixed $id = null): string
     {
         $endpoint = $this->endpoint;
 

--- a/tests/Unit/Databases/FakeSchemaManager.php
+++ b/tests/Unit/Databases/FakeSchemaManager.php
@@ -2,11 +2,18 @@
 
 namespace Tests\Unit\Databases;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 
+/**
+ * @extends AbstractSchemaManager<AbstractPlatform>
+ */
 class FakeSchemaManager extends AbstractSchemaManager
 {
+    /**
+     * @var array<string>
+     */
     private array $databases = ['information_schema', 'mysql', 'performance_schema', 'servidor_testing'];
 
     public function __construct()

--- a/tests/Unit/Http/Requests/System/CreateUserTest.php
+++ b/tests/Unit/Http/Requests/System/CreateUserTest.php
@@ -11,6 +11,9 @@ class CreateUserTest extends TestCase
 {
     use ValidatesFormRequest;
 
+    /**
+     * @var array<string, array<int, string>|string>
+     */
     public array $gidRule = ['gid' => 'required_unless:user_group,true'];
 
     public function setUp(): void
@@ -64,14 +67,14 @@ class CreateUserTest extends TestCase
         $this->shouldPass($validator, 1);
     }
 
-    private function shouldFail(Validator $validator, $value): void
+    private function shouldFail(Validator $validator, int|string $value): void
     {
         $message = $this->validationMessage('gid', $value, 'fail', 'passed');
 
         $this->assertFalse($validator->passes(), $message);
     }
 
-    private function shouldPass(Validator $validator, $value): void
+    private function shouldPass(Validator $validator, int|string $value): void
     {
         $message = $this->validationMessage('gid', $value, 'pass', 'failed');
 

--- a/tests/Unit/Projects/Services/LogFileTest.php
+++ b/tests/Unit/Projects/Services/LogFileTest.php
@@ -12,9 +12,9 @@ class LogFileTest extends TestCase
 {
     use RefreshDatabase;
 
-    private $baseDir = '/home/logrel/laravel';
+    private string $baseDir = '/home/logrel/laravel';
 
-    private $laravelLog = '/storage/logs/laravel.log';
+    private string $laravelLog = '/storage/logs/laravel.log';
 
     /** @test */
     public function relative_paths_are_prefixed_with_docroot(): void

--- a/tests/Unit/Rules/DomainTest.php
+++ b/tests/Unit/Rules/DomainTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Unit\Rules;
 
+use Illuminate\Validation\Validator;
 use Servidor\Rules\Domain;
 use Tests\TestCase;
 
 class DomainTest extends TestCase
 {
     /**
-     * @var array
+     * @var array<array-key, mixed>
      */
     private $rules;
 
@@ -138,12 +139,12 @@ class DomainTest extends TestCase
         $this->assertFalse($this->validate('1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.12345678.90.example.com'));
     }
 
-    private function validate($value)
+    private function validate(string $value): bool
     {
         return $this->getValidator($value)->passes();
     }
 
-    private function getValidator($value)
+    private function getValidator(string $value): Validator
     {
         return $this->validator->make(
             ['domain' => $value],

--- a/tests/ValidatesFormRequest.php
+++ b/tests/ValidatesFormRequest.php
@@ -7,9 +7,9 @@ use Illuminate\Validation\Validator;
 trait ValidatesFormRequest
 {
     /**
-     * @var array
+     * @var array<int> mixed
      */
-    private $rules;
+    private array $rules;
 
     /**
      * @var \Illuminate\Validation\Factory
@@ -22,12 +22,15 @@ trait ValidatesFormRequest
         $this->validator = $this->app['validator'];
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     private function validateAll(array $data): bool
     {
         return $this->getValidator($data)->passes();
     }
 
-    private function validateField(string $field, $value): bool
+    private function validateField(string $field, mixed $value): bool
     {
         return $this->getValidator(
             [$field => $value],
@@ -35,7 +38,7 @@ trait ValidatesFormRequest
         )->passes();
     }
 
-    private function validateFieldFails(string $field, $value): void
+    private function validateFieldFails(string $field, mixed $value): void
     {
         $this->assertFalse(
             $this->validateField($field, $value),
@@ -43,7 +46,7 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validateFieldPasses(string $field, $value): void
+    private function validateFieldPasses(string $field, mixed $value): void
     {
         $this->assertTrue(
             $this->validateField($field, $value),
@@ -51,7 +54,7 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validateChildField(string $field, string $parent, $value, bool $nested = true): bool
+    private function validateChildField(string $field, string $parent, mixed $value, bool $nested = true): bool
     {
         $glue = $nested ? '.*.' : '.';
         $rule = $parent . $glue . $field;
@@ -63,7 +66,7 @@ trait ValidatesFormRequest
         )->passes();
     }
 
-    private function validateChildFieldFails(string $field, string $parent, $value, bool $nested = true): void
+    private function validateChildFieldFails(string $field, string $parent, mixed $value, bool $nested = true): void
     {
         $glued = $nested ? "{$parent}.*.{$field}" : "{$parent}.{$field}";
 
@@ -73,7 +76,7 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validateChildFieldPasses(string $field, string $parent, $value, bool $nested = true): void
+    private function validateChildFieldPasses(string $field, string $parent, mixed $value, bool $nested = true): void
     {
         $glued = $nested ? "{$parent}.*.{$field}" : "{$parent}.{$field}";
 
@@ -83,7 +86,7 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validateConfigField(string $property, $value): bool
+    private function validateConfigField(string $property, mixed $value): bool
     {
         $data = [$property => $value];
         $rule = 'config.' . $property;
@@ -100,7 +103,7 @@ trait ValidatesFormRequest
         )->passes();
     }
 
-    private function validateConfigFieldFails(string $field, $value): void
+    private function validateConfigFieldFails(string $field, mixed $value): void
     {
         $this->assertFalse(
             $this->validateConfigField($field, $value),
@@ -108,7 +111,7 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validateConfigFieldPasses(string $field, $value): void
+    private function validateConfigFieldPasses(string $field, mixed $value): void
     {
         $this->assertTrue(
             $this->validateConfigField($field, $value),
@@ -116,13 +119,17 @@ trait ValidatesFormRequest
         );
     }
 
-    private function validationMessage(string $field, $value, string $expected, string $actual): string
+    private function validationMessage(string $field, mixed $value, string $expected, string $actual): string
     {
         return "Expected field '{$field}' to {$expected} validation with value '"
             . (\is_array($value) || \is_object($value)
             ? json_encode($value) : $value) . "', but it {$actual}.";
     }
 
+    /**
+     * @param array<mixed> $data
+     * @param array<mixed> $rules
+     */
     private function getValidator(array $data, array $rules = []): Validator
     {
         return $this->validator->make($data, $rules ?: $this->rules);


### PR DESCRIPTION
Resolves some ~240 errors mostly with missing return/param hints or missing array key/value typings. Phan seems to support an increasingly limited amount of detection/parsing; suppressing so much is cumbersome.