### PR TITLE
Auto-install a systemd unit to process the queue

### DIFF
--- a/build/installer/_install.sh
+++ b/build/installer/_install.sh
@@ -10,6 +10,9 @@ install_servidor() {
     log "Patching nginx config..."
     patch_nginx && systemctl reload nginx.service
 
+    log "Installing Systemd unit files..."
+    setup_systemd_units
+
     finalise && print_success
 }
 
@@ -122,6 +125,12 @@ patch_nginx() {
 
     log "Setting owner to www-data on main web root..."
     chown www-data:www-data /var/www
+}
+
+setup_systemd_units() {
+    systemd_unit > /lib/systemd/system/servidor.service
+
+    systemctl daemon-reload && systemctl enable servidor.service --now
 }
 
 finalise() {

--- a/build/installer/_templates.sh
+++ b/build/installer/_templates.sh
@@ -81,6 +81,24 @@ nginx_default_page() {
 EOF
 }
 
+systemd_unit() {
+    cat << EOF
+[Unit]
+Description=Servidor queue worker
+
+[Service]
+User=servidor
+Group=servidor
+WorkingDirectory=/var/servidor
+ExecStart=/usr/bin/php artisan queue:work -v --max-time=3600
+ExecStop=/usr/bin/php artisan queue:restart
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
 vagrant_zshrc() {
     cat << EOF
 alias as-web="sudo -u www-data"


### PR DESCRIPTION
Adds `servidor.service` to /lib/systemd/system so the `queue:work` artisan command can be started—and kept alive—with systemd commands.

The service is enabled and started by default so there should no longer be any need to manually start anything with `vagrant ssh -c 'cd /var/servidor && php artisan queue:work'`.