### PR TITLE
Fix project config not saving correctly for SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+* [projects] SSL certificate/key paths are now set correctly in service configs
 
 
 ## [0.16.0] - 2023-03-18

--- a/app/Projects/Actions/SaveSslCertificate.php
+++ b/app/Projects/Actions/SaveSslCertificate.php
@@ -39,11 +39,16 @@ class SaveSslCertificate
 
     public function execute(): void
     {
+        \assert($this->service->config instanceof Collection);
+
         $this->createCertsDir($this->service->project);
 
-        \assert($this->service->config instanceof Collection);
-        $this->service->config['sslCertificate'] = $this->saveCert($this->config);
-        $this->service->config['sslPrivateKey'] = $this->saveKey($this->config);
+        $config = $this->service->config;
+        $config['sslCertificate'] = $this->saveCert($this->config);
+        $config['sslPrivateKey'] = $this->saveKey($this->config);
+
+        $this->service->config = $config;
+        $this->service->save();
     }
 
     private function createCertsDir(Project $project): bool

--- a/tests/Feature/Api/Projects/Actions/SaveSslCertTest.php
+++ b/tests/Feature/Api/Projects/Actions/SaveSslCertTest.php
@@ -71,7 +71,7 @@ class SaveSslCertTest extends TestCase
      */
     public function certs_are_replaced_with_paths_in_the_database(ProjectService $service): void
     {
-        $this->assertEquals('/var/servidor/storage/certs/ssl-test/ssl.test.crt', $service->config->get('sslCertificate'));
+        $this->assertEquals(storage_path('certs/ssl-test/ssl.test.crt'), $service->config->get('sslCertificate'));
     }
 
     /** @test */

--- a/tests/Feature/Api/Projects/Actions/SaveSslCertTest.php
+++ b/tests/Feature/Api/Projects/Actions/SaveSslCertTest.php
@@ -12,7 +12,7 @@ class SaveSslCertTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function certs_get_written_when_saving_project(): void
+    public function certs_get_written_when_saving_project(): ProjectService
     {
         $cert = 'storage/certs/ssl-test/ssl.test.crt';
         $key = 'storage/certs/ssl-test/ssl.test.key';
@@ -32,6 +32,8 @@ class SaveSslCertTest extends TestCase
 
         $this->assertFileExists($cert);
         $this->assertFileExists($key);
+
+        return $service;
     }
 
     /** @test */
@@ -60,6 +62,16 @@ class SaveSslCertTest extends TestCase
 
         $this->assertFileExists($cert);
         $this->assertFileExists($key);
+    }
+
+    /**
+     * @test
+     *
+     * @depends certs_get_written_when_saving_project
+     */
+    public function certs_are_replaced_with_paths_in_the_database(ProjectService $service): void
+    {
+        $this->assertEquals('/var/servidor/storage/certs/ssl-test/ssl.test.crt', $service->config->get('sslCertificate'));
     }
 
     /** @test */


### PR DESCRIPTION
This fixes an issue where you could create a project with an SSL certificate and both the cert+key would save correctly into the certs dir, but the paths weren't being saved in the model's config Collection.