### PR TITLE
Fixes various dark-mode bugs in Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * [projects] SSL certificate/key paths are now set correctly in service configs
 * [projects] Creation wizard and project lists finally look better in Dark mode
+* [projects] Custom repositories are now shown correctly on the confirmation screen
 
 
 ## [0.16.0] - 2023-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * [projects] SSL certificate/key paths are now set correctly in service configs
+* [projects] Creation wizard and project lists finally look better in Dark mode
 
 
 ## [0.16.0] - 2023-03-18

--- a/resources/js/components/ProgressModal.vue
+++ b/resources/js/components/ProgressModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-modal size="tiny" v-model="visible">
+    <sui-modal :class="darkMode ? 'inverted' : ''" size="tiny" v-model="visible">
         <sui-modal-header>{{ title }}</sui-modal-header>
         <sui-progress attached top :percent="done" />
         <sui-modal-content>
@@ -14,11 +14,11 @@
         </sui-modal-content>
         <sui-modal-actions v-if="button">
 
-            <sui-button v-if="'action' in button"
+            <sui-button v-if="'action' in button" :inverted="darkMode"
                 :color="button.colour" :content="button.text"
                 @click="$store.dispatch(button.action)" />
 
-            <router-link is="sui-button" :to="button.route" v-else
+            <router-link is="sui-button" :to="button.route" :inverted="darkMode" v-else
                 :color="button.colour" :content="button.text" />
 
         </sui-modal-actions>

--- a/resources/js/components/Projects/ConfirmationForm.vue
+++ b/resources/js/components/Projects/ConfirmationForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="$emit('created', true)">
+    <sui-form @submit.prevent="$emit('created', true)" :inverted="darkMode">
 
         <sui-divider />
 
@@ -19,17 +19,23 @@
 
         <sui-divider hidden />
 
-        <sui-button positive size="big" v-if="template == 'Clean Slate'">
+        <sui-button color="green" inverted size="big" v-if="darkMode && template == 'Clean Slate'">
+            Create Project
+        </sui-button>
+        <sui-button positive size="big" v-else-if="template == 'Clean Slate'">
             Create Project
         </sui-button>
         <div v-else>
-            <sui-button positive size="big">
+            <sui-button color="green" inverted size="big" v-if="darkMode">
+                Save and start the {{ template }} application
+            </sui-button>
+            <sui-button positive size="big" v-else>
                 Save and start the {{ template }} application
             </sui-button>
 
-            <sui-divider horizontal>Or</sui-divider>
+            <sui-divider horizontal :inverted="darkMode">Or</sui-divider>
 
-            <sui-button primary type="button"
+            <sui-button primary type="button" :inverted="darkMode"
                         content="Just save the project"
                         @click="$emit('created', false)" />
         </div>

--- a/resources/js/components/Projects/Services/DomainForm.vue
+++ b/resources/js/components/Projects/Services/DomainForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="save()">
+    <sui-form :inverted="darkMode" @submit.prevent="save()">
 
         <sui-form-field :error="'domain' in errors">
 

--- a/resources/js/components/Projects/Services/PhpVersions.vue
+++ b/resources/js/components/Projects/Services/PhpVersions.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="$emit('next')">
+    <sui-form @submit.prevent="$emit('next')" :inverted="darkMode">
 
         <sui-form-field :error="'php_version' in errors">
             <sui-dropdown required selection :options="versions"

--- a/resources/js/components/Projects/Services/RedirectForm.vue
+++ b/resources/js/components/Projects/Services/RedirectForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="save()">
+    <sui-form @submit.prevent="save()" :inverted="darkMode">
 
         <sui-form-fields>
             <sui-form-field :width="9">

--- a/resources/js/components/Projects/Services/SourceSelector.vue
+++ b/resources/js/components/Projects/Services/SourceSelector.vue
@@ -12,7 +12,8 @@
 
         <sui-form-field :error="'repository' in errors" v-if="source.provider === 'custom'">
             <label>Repository URL:</label>
-            <sui-input :value="source.url" @input="setValue('url', $event)" required />
+            <sui-input required placeholder="https://git@mydomain.example/repo.git"
+                :value="source.repository" @input="setValue('repository', $event)" />
             <sui-label basic color="red" pointing v-if="'repository' in errors">
                 {{ errors['repository'][0] }}
             </sui-label>

--- a/resources/js/components/Projects/Services/SourceSelector.vue
+++ b/resources/js/components/Projects/Services/SourceSelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="$emit('next')">
+    <sui-form @submit.prevent="$emit('next')" :inverted="darkMode">
 
         <sui-form-fields inline>
             <label>Source Provider</label>

--- a/resources/js/components/Projects/Services/SslForm.vue
+++ b/resources/js/components/Projects/Services/SslForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-form @submit.prevent="$emit('next')">
+    <sui-form @submit.prevent="$emit('next')" :inverted="darkMode">
 
         <sui-form-field :error="'config.ssl' in errors">
             <sui-checkbox toggle :checked="value.ssl"

--- a/resources/js/components/Projects/Services/TemplateSelector.vue
+++ b/resources/js/components/Projects/Services/TemplateSelector.vue
@@ -2,9 +2,9 @@
     <sui-card-group :items-per-row="2">
 
         <sui-card
-            :class="!tpl.disabled && 'link ' + tpl.colour"
             @click="tpl.disabled || $emit('selected', tpl)"
             v-for="tpl in templates"
+            :class="cardClass(tpl)"
             :key="tpl.name"
         >
             <template-card :template="tpl" />
@@ -24,6 +24,17 @@ export default {
         templates: {
             type: Array,
             default: () => [],
+        },
+    },
+    methods: {
+        cardClass(tpl) {
+            let cardClass = this.darkMode ? 'inverted ' : '';
+
+            if (!tpl.disabled) {
+                cardClass += `link ${tpl.colour}`;
+            }
+
+            return cardClass;
         },
     },
 };

--- a/resources/js/components/Projects/StepButtons.vue
+++ b/resources/js/components/Projects/StepButtons.vue
@@ -2,13 +2,21 @@
     <div>
         <sui-divider hidden />
 
-        <sui-button negative @click="$emit('cancel')"
+        <sui-button @click="$emit('cancel')"
+                    inverted color="red" v-if="darkMode"
+                    content="Cancel"
+                    icon="close"
+                    label-position="left"
+                    type="button" />
+        <sui-button @click="$emit('cancel')"
+                    v-else negative
                     content="Cancel"
                     icon="close"
                     label-position="left"
                     type="button" />
 
         <sui-button primary floated="right"
+                    :inverted="darkMode"
                     content="Next"
                     icon="right arrow"
                     label-position="right" />

--- a/resources/js/components/Projects/StepList.vue
+++ b/resources/js/components/Projects/StepList.vue
@@ -1,5 +1,5 @@
 <template>
-    <sui-step-group vertical fluid>
+    <sui-step-group vertical fluid :class="darkMode && 'inverted'">
 
         <sui-step v-for="s in steps"
                   :active="selected == s.name"

--- a/resources/js/pages/Projects/NewProject.vue
+++ b/resources/js/pages/Projects/NewProject.vue
@@ -9,45 +9,45 @@
 
         <sui-grid-column :width="10">
 
-            <sui-segment v-if="step == 'template'">
+            <sui-segment v-if="step == 'template'" :inverted="darkMode">
                 <h3 is="sui-header">First pick a template to get started</h3>
                 <sui-message negative v-if="'template' in errors"
                     :content="errors['template'][0]" />
                 <template-selector :templates="templates"
-                    @selected="setAppTemplate" />
+                    @selected="setAppTemplate" :inverted="darkMode" />
             </sui-segment>
 
-            <sui-segment v-else-if="step == 'phpver'">
+            <sui-segment v-else-if="step == 'phpver'" :inverted="darkMode">
                 <h3 is="sui-header">If your project requires an older PHP, set it here</h3>
                 <php-versions :errors="errors" v-model="defaultApp.config.phpVersion"
                     @next="nextStep('phpver')" @cancel="cancel" />
             </sui-segment>
 
-            <sui-segment v-else-if="step == 'source'">
+            <sui-segment v-else-if="step == 'source'" :inverted="darkMode">
                 <h3 is="sui-header">Where are the project files stored?</h3>
                 <source-selector :errors="errors" :providers="providers"
                     v-model="defaultApp" @next="nextStep('source')" @cancel="cancel" />
             </sui-segment>
 
-            <sui-segment v-else-if="step == 'domain'">
+            <sui-segment v-else-if="step == 'domain'" :inverted="darkMode">
                 <h3 is="sui-header">Set the main entry point for your app</h3>
                 <domain-form :errors="errors" v-model="defaultApp"
                     @next="nextStep('domain')" @cancel="cancel" />
             </sui-segment>
 
-            <sui-segment v-else-if="step == 'ssl'">
+            <sui-segment v-else-if="step == 'ssl'" :inverted="darkMode">
                 <h3 is="sui-header">Have an SSL Certificate to use?</h3>
                 <ssl-form :errors="errors" v-model="defaultApp.config"
                     @next="nextStep('ssl')" @cancel="cancel" />
             </sui-segment>
 
-            <sui-segment v-else-if="step == 'redirect'">
+            <sui-segment v-else-if="step == 'redirect'" :inverted="darkMode">
                 <h3 is="sui-header">Time to set the target!</h3>
                 <redirect-form :errors="errors" :domain="defaultApp.domain"
                     @next="setRedirect" @cancel="cancel" />
             </sui-segment>
 
-            <sui-segment padded aligned="center" v-else-if="step == 'confirm'">
+            <sui-segment padded aligned="center" v-else-if="step == 'confirm'" :inverted="darkMode">
                 <h3 is="sui-header">Let's get this Project started!</h3>
                 <confirmation-text :service="defaultApp" :providers="providers" />
                 <confirmation-form :errors="errors" v-model="project.name"

--- a/resources/js/pages/Projects/ProjectList.vue
+++ b/resources/js/pages/Projects/ProjectList.vue
@@ -3,13 +3,14 @@
     <div v-if="projects.length">
 
         <sui-input placeholder="Search..." icon="search"
+            :class="darkMode ? 'inverted search' : 'search'"
             v-model="filter" @keyup.enter="viewSelected" />
 
         <router-link :to="{ name: 'projects.new' }"
                      is="sui-button" primary icon="add"
                      content="New Project" />
 
-        <sui-table selectable>
+        <sui-table selectable :inverted="darkMode">
             <sui-table-body>
                 <sui-table-row v-for="p in filteredProjects" :key="p.id">
                     <sui-table-cell selectable :colspan="getColspan(p)">
@@ -26,7 +27,7 @@
                     </sui-table-cell>
                     <sui-table-cell collapsing v-if="p.services.length">
                         <router-link is="sui-button" basic size="tiny" compact
-                            :to="makeBrowseLink(p)" v-if="canBrowse(p)">
+                            :to="makeBrowseLink(p)" v-if="canBrowse(p)" :inverted="darkMode">
                             <sui-icon name="open folder" /> Browse Source
                         </router-link>
                     </sui-table-cell>
@@ -36,13 +37,13 @@
 
     </div>
 
-    <sui-segment class="placeholder" v-else>
+    <sui-segment class="placeholder" :inverted="darkMode" v-else>
 
         <h3 is="sui-header" text-align="center">
             Seems you don't currently have any projects!
         </h3>
 
-        <router-link :to="{ name: 'projects.new' }"
+        <router-link :to="{ name: 'projects.new' }" :inverted="darkMode"
             is="sui-button" primary icon="add"
             content="Create a Project" />
 

--- a/resources/js/pages/Projects/source-providers.json
+++ b/resources/js/pages/Projects/source-providers.json
@@ -8,5 +8,6 @@
   "urlFormat": "https://bitbucket.org/%REPO%.git"
 }, {
   "name": "custom",
-  "text": "Custom Git URL"
+  "text": "Custom Git URL",
+  "urlFormat": "%REPO%"
 }]

--- a/resources/js/store/modules/Progress.js
+++ b/resources/js/store/modules/Progress.js
@@ -39,7 +39,7 @@ export default {
     },
     actions: {
         activateContinueButton: ({ commit }, route) => {
-            commit('setButton', { route, text: 'Continue' });
+            commit('setButton', { route, colour: 'green', text: 'Continue' });
         },
         hide: ({ commit }) => {
             commit('setVisible', false);

--- a/resources/sass/themes/darkmode-custom.scss
+++ b/resources/sass/themes/darkmode-custom.scss
@@ -6,6 +6,10 @@
         opacity: 0.8;
     }
 
+    .ui.list {
+        background: none;
+    }
+
     .ui.inverted {
         &.sidebar.menu {
             background: rgba(27, 28, 39, 0.8);
@@ -24,6 +28,20 @@
             padding-bottom: 0.62619048em !important;
         }
 
+        &.steps {
+            .step {
+                background: #1b1c1d;
+                border-color: #555;
+                * {
+                    color: rgba(255, 255, 255, 0.9);
+                }
+            }
+            .step.active, .step.active:after {
+                background: #0b0c0d !important;
+            }
+        }
+
+
         &.card {
             background: #1b1c1d !important;
             box-shadow: 0 1px 3px 0 #555, 0 0 0 1px #555 !important;
@@ -34,14 +52,29 @@
             color: rgba(255, 255, 255, 0.6) !important;
         }
 
+        &.search.input {
+            &> input {
+                background: transparent;
+                color: rgba(255, 255, 255, 0.67);
+                &:focus {
+                    color: rgba(255, 255, 255, 0.95);
+                }
+            }
+            .icon {
+                color: #fff;
+            }
+        }
         &.form {
             input:focus {
+                border-color: #555;
                 color: rgba(255, 255, 255, 0.95);
             }
-            input, .selection.dropdown, .selection.dropdown .menu {
+            input, textarea, .selection.dropdown, .selection.dropdown .menu {
                 background: #1b1c1d;
+                border-color: rgba(255, 255, 255, 0.1);
                 color: rgba(255, 255, 255, 0.67);
             }
+            textarea:focus,
             .selection.dropdown .menu,
             .selection.dropdown.active {
                 border-color: #555;
@@ -60,8 +93,28 @@
                 background: transparent;
             }
 
-            .toggle.checkbox input:checked ~ label {
-                color: rgba(255, 255, 255, 0.95) !important;
+            .toggle.checkbox {
+                label:before {
+                    background-color: rgba(255, 255, 255, 0.05);
+                }
+                input:checked ~ label {
+                    color: rgba(255, 255, 255, 0.95) !important;
+                }
+            }
+        }
+
+        &.dimmer {
+            background-color: rgba(0, 0, 0, 0.85);
+        }
+        &.modals .modal {
+            background: #4e5d6c;
+
+            .header, .content, .actions {
+                background: #0b0c0d;
+                color: #fff;
+            }
+            &> .actions {
+                border-top: 1px solid rgb(229 241 253 / 15%);
             }
         }
     }


### PR DESCRIPTION
Applies the inverted attribute to all project creation forms and adds
some extra styles for the steps, dropdowns and checkbox toggle switches.

For buttons, positive is replaced with `color="green"` in dark mode
because the inverted positive is an ugly white-bordered green button and
I'm too lazy to just make it look more like the positive primary button.

Also fixes the placeholder segment on the main project list page.