### PR TITLE
Fix regex for custom repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * [projects] `$request_uri` wasn't being appended when redirecting [non-]www variants
+* [projects] Custom repositories no longer fail validation
 
 
 ## [0.16.1] - 2023-03-27

--- a/app/Http/Requests/Projects/NewProjectService.php
+++ b/app/Http/Requests/Projects/NewProjectService.php
@@ -75,10 +75,13 @@ class NewProjectService extends FormRequest
                 'array:provider,repository,branch',
             ],
             'source.branch' => 'nullable|string',
-            'source.provider' => 'required_unless:template,redirect|in:github,bitbucket',
+            'source.provider' => 'required_unless:template,redirect|in:github,bitbucket,custom',
             'source.repository' => [
                 'required_unless:template,redirect',
-                'regex:_^([a-z-]+)/([a-z-]+)$_i',
+                'regex:/(' . implode(')|(', [
+                    '([a-z-]+)\/([a-z-]+)',
+                    '((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)(\/)?',
+                ]) . ')/i',
                 'nullable',
             ],
         ];

--- a/tests/Unit/Http/Requests/Projects/NewProjectServiceTest.php
+++ b/tests/Unit/Http/Requests/Projects/NewProjectServiceTest.php
@@ -115,8 +115,12 @@ class NewProjectServiceTest extends TestCase
     public function source_repository_must_be_a_valid_url(): void
     {
         $this->validateConfigFieldPasses('source.repository', 'foo/bar');
-        $this->validateConfigFieldFails('source.repository', 'foo/bar.git');
-        $this->validateConfigFieldFails('source.repository', 'https://github.com/foo/bar');
+        $this->validateConfigFieldPasses('source.repository', 'foo/bar.git');
+        $this->validateConfigFieldPasses('source.repository', '/tmp/foo/bar');
+        $this->validateConfigFieldPasses('source.repository', 'git@github.com:foo/bar.git');
+        $this->validateConfigFieldPasses('source.repository', 'http://git@github.com/foo/bar.git');
+        $this->validateConfigFieldPasses('source.repository', 'https://git@github.com/foo/bar.git');
+
         $this->validateConfigFieldFails('source.repository', 'localhost');
         $this->validateConfigFieldFails('source.repository', 42);
         $this->validateConfigFieldFails('source.repository', true);


### PR DESCRIPTION
Updates the repository validation regex to allow for full repo urls, and adds 'custom' to the list of allowed source repository providers.